### PR TITLE
Display Item label (except on popup title)

### DIFF
--- a/Initium-Odp/src/com/universeprojects/miniup/server/GameUtils.java
+++ b/Initium-Odp/src/com/universeprojects/miniup/server/GameUtils.java
@@ -816,15 +816,15 @@ public class GameUtils
     
     public static String renderItem(HttpServletRequest request, CachedEntity item, boolean popupEmbedded)
     {
-    	if (item==null)
-    		return "";
-    	
-    	String qualityClass = determineQuality(item.getProperties());
-    	String label = (String)item.getProperty("label"); 
-    	if (label==null || label.trim().equals(""))
-    		label = (String)item.getProperty("name");
-
-    	if (popupEmbedded)
+		if (item==null)
+			return "";
+		
+		String qualityClass = determineQuality(item.getProperties());
+		String label = (String)item.getProperty("label"); 
+		if (label==null || label.trim().equals(""))
+			label = (String)item.getProperty("name");
+		
+		if (popupEmbedded)
 			return "<a class='"+qualityClass+"' onclick='reloadPopup(this, \""+WebUtils.getFullURL(request)+"\", event)' rel='viewitemmini.jsp?itemId="+item.getKey().getId()+"'><div class='main-item-image-backing'><img src='"+item.getProperty("icon")+"' border=0/></div><div class='main-item-name'>"+label+"</div></a>";
 		else
 			return "<a class='clue "+qualityClass+"' rel='viewitemmini.jsp?itemId="+item.getKey().getId()+"'><div class='main-item-image-backing'><img src='"+item.getProperty("icon")+"' border=0/></div><div class='main-item-name'>"+label+"</div></a>";
@@ -1083,7 +1083,7 @@ public class GameUtils
 			if (description!=null)
 			{
 				sb.append("<div class='buff-detail-description item-flavor-description'>");
-				sb.append(buff.getProperty("description"));
+				sb.append(description);
 				sb.append("</div>");
 			}
 			Date expiry = (Date)buff.getProperty("expiry");

--- a/Initium-Odp/src/com/universeprojects/miniup/server/GameUtils.java
+++ b/Initium-Odp/src/com/universeprojects/miniup/server/GameUtils.java
@@ -820,12 +820,14 @@ public class GameUtils
     		return "";
     	
     	String qualityClass = determineQuality(item.getProperties());
-    	
-    	
+    	String label = (String)item.getProperty("label"); 
+    	if (label==null || label.trim().equals(""))
+    		label = (String)item.getProperty("name");
+
     	if (popupEmbedded)
-    		return "<a class='"+qualityClass+"' onclick='reloadPopup(this, \""+WebUtils.getFullURL(request)+"\", event)' rel='viewitemmini.jsp?itemId="+item.getKey().getId()+"'><div class='main-item-image-backing'><img src='"+item.getProperty("icon")+"' border=0/></div><div class='main-item-name'>"+item.getProperty("name")+"</div></a>";
-    	else
-    		return "<a class='clue "+qualityClass+"' rel='viewitemmini.jsp?itemId="+item.getKey().getId()+"'><div class='main-item-image-backing'><img src='"+item.getProperty("icon")+"' border=0/></div><div class='main-item-name'>"+item.getProperty("name")+"</div></a>";
+			return "<a class='"+qualityClass+"' onclick='reloadPopup(this, \""+WebUtils.getFullURL(request)+"\", event)' rel='viewitemmini.jsp?itemId="+item.getKey().getId()+"'><div class='main-item-image-backing'><img src='"+item.getProperty("icon")+"' border=0/></div><div class='main-item-name'>"+label+"</div></a>";
+		else
+			return "<a class='clue "+qualityClass+"' rel='viewitemmini.jsp?itemId="+item.getKey().getId()+"'><div class='main-item-image-backing'><img src='"+item.getProperty("icon")+"' border=0/></div><div class='main-item-name'>"+label+"</div></a>";
     }
 
     public static String renderCollectable(CachedEntity item)
@@ -1077,9 +1079,13 @@ public class GameUtils
 				}
 			}
 			sb.append("</div>");
-			sb.append("<div class='buff-detail-description item-flavor-description'>");
-			sb.append(""+buff.getProperty("description"));
-			sb.append("</div>");
+			String description = (String)buff.getProperty("description");
+			if (description!=null)
+			{
+				sb.append("<div class='buff-detail-description item-flavor-description'>");
+				sb.append(buff.getProperty("description"));
+				sb.append("</div>");
+			}
 			Date expiry = (Date)buff.getProperty("expiry");
 			if (expiry!=null)
 				sb.append("<div class='buff-detail-expiry'>Expires in "+getTimePassedShortString(expiry)+"</div>");

--- a/Initium-Odp/src/com/universeprojects/miniup/server/commands/CommandRavenPayRespects.java
+++ b/Initium-Odp/src/com/universeprojects/miniup/server/commands/CommandRavenPayRespects.java
@@ -1,0 +1,143 @@
+package com.universeprojects.miniup.server.commands;
+
+import java.util.List;
+import java.util.Random;
+import java.util.Map;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import com.universeprojects.cacheddatastore.CachedDatastoreService;
+import com.universeprojects.cacheddatastore.CachedEntity;
+import com.google.appengine.api.datastore.Key;
+import com.universeprojects.miniup.server.ODPDBAccess;
+import com.universeprojects.miniup.server.commands.framework.Command;
+import com.universeprojects.miniup.server.commands.framework.UserErrorMessage;
+import com.universeprojects.miniup.server.commands.framework.Command.JavascriptResponse;
+
+
+/**
+ * Does one of the following:
+ *  - If has Buff Blessing of the Ebon Raven: Nothing
+ *  - If not equipped Raven Guards: Nothing
+ *  - If not full HP: Set Buff 1h with no modifiers, heals HP
+ *  - If dogecoins < 1000: Set Buff 1h with no modifiers, dogecoins +1000
+ *  - If has Buff Well Rested+Buff Pumped: Set Buff 30m with all stats +1
+ *  - Set Buff 30m with random stat +1
+ * 
+ * Usage notes:
+ * Checks if caller is at Burial Site of The Ebon Raven and if so adds buff
+ * according to the rules above. 
+ * 
+ * Parameters:
+ * 		none 
+ * 
+ * @author NJ
+ *
+ */
+public class CommandRavenPayRespects extends Command {
+
+	public CommandRavenPayRespects(HttpServletRequest request, HttpServletResponse response) 
+	{
+		super(request, response);
+	}
+
+	@Override
+	public void run(Map<String, String> parameters) throws UserErrorMessage 
+	{
+		ODPDBAccess db = getDB();
+		CachedEntity character = db.getCurrentCharacter(request);
+		
+		// Verify the caller is at Burial Site of The Ebon Raven
+		Key key = (Key)character.getProperty("locationKey");
+		if (key==null)
+			throw new UserErrorMessage("You cannot do that here.");
+		if (key.getId()!=4808618326097920L)
+			throw new UserErrorMessage("You cannot do that here.");
+		
+		// Get all buffs and check for Blessing of the Raven
+		List<CachedEntity> buffs = db.getBuffsFor(character.getKey());
+		if (buffs!=null && buffs.isEmpty()==false)
+		{
+			for(CachedEntity buff:buffs)
+			{
+				if ("Blessing of the Ebon Raven".equals(buff.getProperty("name")))
+				{
+					setPopupMessage("You feel the spirit of the Ebon Raven's gaze upon you, as if trying to figure out if it had been a mistake to bless you in the first place.");
+					return;
+				}
+			}
+		}
+		
+		// Check if Raven Guards are equipped
+		CachedEntity item = db.getEntity((Key)character.getProperty("equipmentGloves"));
+		if (item==null || "Raven Guards".equals(item.getProperty("name"))==false)
+		{
+			setPopupMessage("You feel the spirit of the Ebon Raven's gaze upon you, as if trying to figure out if you are being sincere.");
+			return;
+		}
+		
+		// At this point, we're always at least setting the buff, so get ds
+		// and set Refresh for client so buff shows up
+		CachedDatastoreService ds = getDS();
+		setJavascriptResponse(JavascriptResponse.FullPageRefresh);
+
+		// Check for Hp trigger and if met, set buff effect.
+		Double curHp = (Double)character.getProperty("hitpoints");
+		Double maxHp = (Double)character.getProperty("maxHitpoints");
+		if (curHp!=null && maxHp!=null && curHp>0 && curHp<maxHp)
+		{
+			ds.put(db.awardBuff(ds, character.getKey(), "/images/small/Pixel_Art-Icons-Holy-S_Holy07.png", "Blessing of the Ebon Raven", "The spirit of the Ebon Raven has blessed you. It left you restored.", 3600, null, null, null, null, null, null, 1));
+			character.setProperty("hitpoints", maxHp);
+			ds.put(character);
+			return;
+		}
+		
+		// Check for dogecoin trigger and if met, set buff effect.
+		Long dogecoins = (Long)character.getProperty("dogecoins");
+		if (dogecoins!=null && dogecoins<1000)
+		{
+			ds.put(db.awardBuff(ds, character.getKey(), "/images/small/Pixel_Art-Icons-Holy-S_Holy07.png", "Blessing of the Ebon Raven", "The spirit of the Ebon Raven has blessed you. It left you enriched.", 3600, null, null, null, null, null, null, 1));
+			character.setProperty("dogecoins", dogecoins+1000);
+			ds.put(character);
+			return;
+		}
+		
+		// Check for buff trigger and if met, set buff effect.
+		if (buffs!=null && buffs.isEmpty()==false)
+		{
+			boolean trigger1 = false;
+			boolean trigger2 = false;
+			for(CachedEntity buff:buffs)
+			{
+				String name = (String)buff.getProperty("name");
+				if ("Well Rested".equals(name))
+					trigger1 = true;
+				if ("Pumped!".equals(name))
+					trigger2 = true;
+			}
+			if (trigger1 && trigger2)
+			{
+				ds.put(db.awardBuff(ds, character.getKey(), "/images/small/Pixel_Art-Icons-Holy-S_Holy07.png", "Blessing of the Ebon Raven", "The spirit of the Ebon Raven has blessed you. It left you enchanted.", 1800, "strength", "+1", "dexterity", "+1", "intelligence", "+1", 1));
+				return;
+			}
+		}
+		
+		// all previous triggers failed, set buff effect
+		Random rnd = new Random();
+		int stat = rnd.nextInt(3);
+		switch (stat) {
+		case 0:
+			ds.put(db.awardBuff(ds, character.getKey(), "/images/small/Pixel_Art-Icons-Holy-S_Holy07.png", "Blessing of the Ebon Raven", "The spirit of the Ebon Raven has blessed you. It left you empowered.", 1800, "strength", "+1", null, null, null, null, 1));
+			return;
+		case 1:
+			ds.put(db.awardBuff(ds, character.getKey(), "/images/small/Pixel_Art-Icons-Holy-S_Holy07.png", "Blessing of the Ebon Raven", "The spirit of the Ebon Raven has blessed you. It left you invigorated.", 1800, "dexterity", "+1", null, null, null, null, 1));
+			return;
+		case 2:
+			ds.put(db.awardBuff(ds, character.getKey(), "/images/small/Pixel_Art-Icons-Holy-S_Holy07.png", "Blessing of the Ebon Raven", "The spirit of the Ebon Raven has blessed you. It left you enlightened.", 1800, "intelligence", "+1", null, null, null, null, 1));
+			return;
+		}
+		
+	}
+
+}

--- a/Initium-Odp/war/odp/javascript/script.js
+++ b/Initium-Odp/war/odp/javascript/script.js
@@ -465,7 +465,7 @@ function createCampsite()
 		if (name!=null && name!="")
 		{
 			window.location.href='ServletCharacterControl?type=createCampsite&name='+encodeURIComponent(name);
-			popupPermanentOverlay("Creating a new campsite..", "You are hard at work setting up a new camp. Make sure you defend it or it wont last long!");
+			popupPermanentOverlay("Creating a new campsite..", "You are hard at work setting up a new camp. Make sure you defend it or it won't last long!");
 			localStorage.setItem("campsiteName", name);
 		}
 	});
@@ -514,6 +514,8 @@ function exitFullscreenChat()
 
 function loadLocationItems()
 {
+	closeAllPagePopups();
+	closeAllTooltips();
 	pagePopup("ajax_moveitems.jsp?preset=location");
 //	$("#main-itemlist").load("locationitemlist.jsp");
 //	$("#main-itemlist").click(function(){
@@ -523,6 +525,8 @@ function loadLocationItems()
 
 function loadLocationCharacters()
 {
+	closeAllPagePopups();
+	closeAllTooltips();
 	pagePopup("locationcharacterlist.jsp");
 //	$("#main-characterlist").click(function(){
 //		$("#main-characterlist").html("<div class='boldbox' onclick='loadLocationCharacters()'><h4 id='main-characterlist-close'>Nearby characters</h4></div>");
@@ -531,6 +535,8 @@ function loadLocationCharacters()
 
 function loadLocationMerchants()
 {
+	closeAllPagePopups();
+	closeAllTooltips();
 	pagePopup("locationmerchantlist.jsp");
 //	$("#main-merchantlist").load("locationmerchantlist.jsp");
 //	$("#main-merchantlist").click(function(){
@@ -995,7 +1001,6 @@ function closePagePopup()
 
 function closeAllPagePopups()
 {
-	// Clear all popups before opening inventory
 	while (currentPopupStackIndex>0)
 	{		
 		closePagePopup();
@@ -1051,20 +1056,22 @@ function loadInlineCollectables()
 
 function inventory()
 {
-	// Clear all popups before opening inventory
 	closeAllPagePopups();
+	closeAllTooltips();
 	pagePopup("ajax_inventory.jsp");
 }
 
 function viewChangelog()
 {
 	closeAllPopups();
+	closeAllTooltips();
 	pagePopup("ajax_changelog.jsp");
 }
 
 function viewSettings()
 {
 	closeAllPopups();
+	closeAllTooltips();
 	pagePopup("ajax_settings.jsp");
 }
 
@@ -1472,34 +1479,31 @@ function fullpageRefresh()
 // Shortcut key bindings
 
 
-window.disableShortcuts = false;
 $(document).keyup(function(event){
-	if (window.disableShortcuts==false)
+	var buttonToPress = $('[shortcut="'+event.which+'"]');
+	if (buttonToPress.length>0)
 	{
-		var buttonToPress = $('[shortcut="'+event.which+'"]');
-		if (buttonToPress.length>0)
-		{
-			window.disableShortcuts = true;
-			buttonToPress[0].click();
-		}
-		
-		if (event.which==80)
-		{
-			viewProfile();
-		}
-		else if (event.which==73)
-		{
-			inventory();
-		}
-		else if (event.which==77)
-		{
-			viewMap();
-		}
-		else if (event.which==66)
-		{
-			window.disableShortcuts = true;
-			window.location.href='main.jsp';
-		}
+		buttonToPress[0].click();
+	}
+	else if (event.which==73) // I
+	{
+		inventory();
+	}
+	else if (event.which==77) // M
+	{
+		viewMap();
+	}
+	else if (event.which==79) // O
+	{
+		viewSettings();
+	}
+	else if (event.which==80) // P
+	{
+		viewProfile();
+	}
+	else if (event.which==76) // Changed to L since B is now for Nearby Characters list
+	{
+		window.location.href='main.jsp';
 	}
 });
 


### PR DESCRIPTION
This should show label instead of name anywhere except in the title of the item popup.
This can be left as a feature to show the base item name that way,
  or the popup display could be changed to show something like Label+"<br>Type: "+name
  but that change can not be made in the ODP

(the reason all lines are removed/added in the comparison is space -> tab whitespace)