### PR TITLE
Load BrowserPopupNotifications-impl.js synchronously.

### DIFF
--- a/Initium-Odp/war/odp/javascript/PopupNotifications.js
+++ b/Initium-Odp/war/odp/javascript/PopupNotifications.js
@@ -123,6 +123,6 @@ var notificationScript = "/odp/javascript/BrowserPopupNotifications-impl.js";
 
 // Load the detected notification version script. Each impl should have a 
 // SetNotificationHandler method that instantiates and assigns the global notifyHandler object.
-$.cachedScript(notificationScript).done(function() {
+$.cachedScript(notificationScript, {async:false}).done(function() {
 	SetNotificationHandler();
 });


### PR DESCRIPTION
requestPermission was failing since the impl wasn't loaded yet, so notifyHandler is still null.