### PR TITLE
Multi-item processing fixes

### DIFF
--- a/Initium-Odp/src/com/universeprojects/miniup/server/HtmlComponents.java
+++ b/Initium-Odp/src/com/universeprojects/miniup/server/HtmlComponents.java
@@ -241,6 +241,7 @@ public class HtmlComponents {
 		String result = "";
 		   result+="<div class='invItem' ref="+item.getKey().getId()+">";
 		   result+="<div class='main-item'>";
+		   result+="<input type=checkbox>";
 		   result+="<div class='main-item-container'>";
 		   result+=GameUtils.renderItem(item)+saleText;
 		   result+="<br>";

--- a/Initium-Odp/src/com/universeprojects/miniup/server/commands/CommandItemsSell.java
+++ b/Initium-Odp/src/com/universeprojects/miniup/server/commands/CommandItemsSell.java
@@ -63,7 +63,7 @@ public class CommandItemsSell extends CommandItemsBase {
 			
 			CachedEntity saleItem = db.newSaleItem(ds, character, batchSale, amount);
 			saleString.append(HtmlComponents.generateSellItemHtml(db,saleItem,request));
-			processedItems.add(saleItem.getKey().getId());
+			processedItems.add(batchSale.getKey().getId());
 		}
 		
 		// If no items were sold, then we're returning an empty string, which won't change

--- a/Initium-Odp/src/com/universeprojects/miniup/server/commands/CommandItemsStoreDelete.java
+++ b/Initium-Odp/src/com/universeprojects/miniup/server/commands/CommandItemsStoreDelete.java
@@ -51,7 +51,8 @@ public class CommandItemsStoreDelete extends CommandItemsBase {
 		
 		addCallbackData("createInvItem", storeString.toString());
 	}
-
+	
+	@Override
 	protected String getEntityType()
 	{
 		return "SaleItem";

--- a/Initium-Odp/src/com/universeprojects/miniup/server/commands/CommandItemsStoreDelete.java
+++ b/Initium-Odp/src/com/universeprojects/miniup/server/commands/CommandItemsStoreDelete.java
@@ -45,8 +45,8 @@ public class CommandItemsStoreDelete extends CommandItemsBase {
 			if ("Sold".equals(storeItem.getProperty("status"))==false)
 			{
 				storeString.append(HtmlComponents.generateInvItemHtml(storeItem));
-				processedItems.add(storeItem.getKey().getId());
 			}
+			processedItems.add(storeItem.getKey().getId());
 		}
 		
 		addCallbackData("createInvItem", storeString.toString());


### PR DESCRIPTION
Add checkboxes to trade window. Return itemId when selling, to remove from original list. Add override annotation to getEntityType of ItemsStoreDelete, and add all items to processedItems (so they can be removed from the original list).