### PR TITLE
Mitigate sound toggle on settings page not working

### DIFF
--- a/Initium-Odp/war/odp/javascript/script.js
+++ b/Initium-Odp/war/odp/javascript/script.js
@@ -2705,8 +2705,12 @@ function toggleEnvironmentSoundEffects(newState)
 	
 	createjs.Sound.muted = enabled;
 	localStorage.setItem("checkboxDisableEnvironmentSoundEffects", enabled+"");
-	
-	
+
+	if (requestedAudioDescriptor !== null)
+	{
+		setAudioDescriptor(requestedAudioDescriptor[0], requestedAudioDescriptor[1], requestedAudioDescriptor[2]);
+		requestedAudioDescriptor = null;
+	}
 	
 	// Set the correct image for the header mute button
 	if (enabled)

--- a/Initium-Odp/war/odp/javascript/script.js
+++ b/Initium-Odp/war/odp/javascript/script.js
@@ -2694,13 +2694,14 @@ function getMusicVolume()
 	return parseInt(setting);
 }
 
-function toggleEnvironmentSoundEffects()
+function toggleEnvironmentSoundEffects(newState)
 {
 	var enabled = isSoundEffectsEnabled();
 	if (enabled==null)
 		enabled = true;
-	
-	
+	if (newState !== undefined) {
+		enabled = newState;
+	}
 	
 	createjs.Sound.muted = enabled;
 	localStorage.setItem("checkboxDisableEnvironmentSoundEffects", enabled+"");

--- a/Initium-Odp/war/odp/javascript/soundeffects.js
+++ b/Initium-Odp/war/odp/javascript/soundeffects.js
@@ -161,6 +161,10 @@ $(document).ready(function(){
 	updateEnvironmentSoundEffectsVolume();
 });
 
+// The parameters passed to setAudioDescriptor when sound effects were
+// disabled, so we can enable it later if desired
+var requestedAudioDescriptor = null;
+
 /**
  * This gets called from the pages that need sound. The audioDescriptor of the location
  * being displayed is to be passed in.
@@ -170,7 +174,10 @@ $(document).ready(function(){
 function setAudioDescriptor(newAudioDescriptor, preset, isOutside)
 {
 	if (isSoundEffectsEnabled()==false)
+	{
+		requestedAudioDescriptor = [newAudioDescriptor, preset, isOutside];
 		return;
+	}
 
 	
 	outsideAudio = isOutside;


### PR DESCRIPTION
`ajax_settings.jsp` already passes the checkbox state as a parameter to `toggleEnvironmentSoundEffects`, so we'll use that to ensure we're always in sync with the checkbox.

**Edit:** Also save arguments to setAudioDescriptor when sound is disabled. So if the user had disabled sound prior to page load, they may actually enable it without needing to reload.