### PR TITLE
CommandRenameUnnamedCharacter bug fix - validate new name, not current name.

### DIFF
--- a/Initium-Odp/src/com/universeprojects/miniup/server/commands/CommandRenameUnnamedPlayer.java
+++ b/Initium-Odp/src/com/universeprojects/miniup/server/commands/CommandRenameUnnamedPlayer.java
@@ -54,7 +54,7 @@ public class CommandRenameUnnamedPlayer extends Command {
 		if(charName.equals("Unnamed")){
 			//looking at ODPDBAccess.isCharacterNameOk(), it appears to do all the validation. Other than checking
 			//if the character is named "Unnamed" no extra validation will be done here.
-			if(db.isCharacterNameOk(this.request, charName)){
+			if(db.isCharacterNameOk(this.request, newName)){
 				
 					//everything looks good. Update the CachedEntity and put it in the database.
 					character.setProperty("name", newName);


### PR DESCRIPTION
Was validating the user's current name instead of the new name to change to.