### PR TITLE
85 - Fixing issues with players entering owned locations

### DIFF
--- a/Initium-Odp/src/com/universeprojects/miniup/server/ODPDBAccess.java
+++ b/Initium-Odp/src/com/universeprojects/miniup/server/ODPDBAccess.java
@@ -36,6 +36,7 @@ import com.google.appengine.api.memcache.MemcacheService.SetPolicy;
 import com.universeprojects.cacheddatastore.AbortTransactionException;
 import com.universeprojects.cacheddatastore.CachedDatastoreService;
 import com.universeprojects.cacheddatastore.CachedEntity;
+import com.universeprojects.cacheddatastore.QueryHelper;
 import com.universeprojects.miniup.server.commands.framework.UserErrorMessage;
 import com.universeprojects.miniup.server.longoperations.AbortedActionException;
 import com.universeprojects.miniup.server.services.ContainerService;
@@ -5076,9 +5077,408 @@ public class ODPDBAccess
 	 * @param currentCharacter
 	 * @param key
 	 */
-	public void doDeleteCombatSite(CachedDatastoreService ds, CachedEntity currentCharacter, Key key) {
-		// TODO Auto-generated method stub
-		
+	public void doDeleteCombatSite(CachedDatastoreService ds, CachedEntity playerCharacter, Key locationKey)
+	{
+		doDeleteCombatSite(ds, playerCharacter, locationKey, false);
 	}
+	
+	/**This will need to be updated as we add more stuff.
+	 * We already need to delete items contained by monsters and items on the ground.
+	 * 
+	 * @param monster
+	 */
+	public void doDeleteCombatSite(CachedDatastoreService ds, CachedEntity playerCharacter, Key locationKey, boolean forceDelete)
+	{
+		if (ds==null)
+			ds = getDB();
+		
+		// Check if the player character is standing in this location, if so get out!
+		if (playerCharacter!=null && playerCharacter.getProperty("locationKey").equals(locationKey))
+			throw new IllegalArgumentException("Not allowed to delete a combat site that still has the player character in it.");
+		
+		
+		CachedEntity location = getEntity(locationKey);
+		if (location==null)
+			return;
+		if ("CombatSite".equals(location.getProperty("type"))==false)
+			return;
+		
+		QueryHelper q = new QueryHelper(ds);
+		List<CachedEntity> characters = q.getFilteredList("Character", "locationKey", locationKey);
+		List<CachedEntity> paths = getPathsByLocation_KeysOnly(locationKey);
+		List<CachedEntity> discoveries = new ArrayList<CachedEntity>();
+		if (playerCharacter!=null)
+			discoveries = getDiscoveriesForCharacterAndLocation(playerCharacter.getKey(), locationKey);
+		List<CachedEntity> items = q.getFilteredList("Item", "containerKey", locationKey);
+		
+
+		boolean hasLiveNpc = false;
+		boolean hideOnly = false;
+		for(CachedEntity character:characters)
+		{
+			if (character.getProperty("type")==null || character.getProperty("type").equals("NPC")==false)
+				hideOnly = true;
+			else if ("NPC".equals(character.getProperty("type")) && (Double)character.getProperty("hitpoints")>0d)
+				hasLiveNpc=true;
+		}
+		
+		
+		// Having the paths size>1 cancels the deletion of the combat site. This is very important so that people don't get
+		// stranded in rare cases where there are other sites branching from this one. The outer branches must be deleted first, 
+		// but we can do that lazily.
+		if ((hideOnly && forceDelete==false) || 
+				(paths.size()>1 && forceDelete==false) || 
+				(hasLiveNpc && forceDelete==false) /*Now we don't delete the site if the NPC is alive*/)
+		{
+			// Delete the discoveries of the paths to this location
+			for(CachedEntity discovery:discoveries)
+			{
+				for(CachedEntity path:paths)
+				{
+					Key discoveryEntityKey = (Key)discovery.getProperty("entityKey");
+					if (discoveryEntityKey.getKind().equals(path.getKey().getKind()) && discoveryEntityKey.getId()==path.getKey().getId())
+					{
+						discovery.setProperty("hidden", "TRUE");
+						ds.put(discovery);
+					}
+				}
+				
+				// Right now discoveries are only used for paths. More may need to be handled later on.
+			}
+			
+			return;
+		}
+		else
+		{
+			
+			
+			// Delete all characters standing in this place (should only be NPCs)
+			for(CachedEntity character:characters)
+				ds.delete(character.getKey());
+			
+			// Delete all items on the ground
+			for(CachedEntity item:items)
+				ds.delete(item.getKey());
+			
+			// Delete all paths to this location
+			for(CachedEntity path:paths)
+				ds.delete(path.getKey());
+			
+			// Delete the discoveries of the paths to this location
+			for(CachedEntity discovery:discoveries)
+			{
+				if (discovery==null)
+					continue;
+				for(CachedEntity path:paths)
+				{
+					Key discoveryEntityKey = (Key)discovery.getProperty("entityKey");
+					if (discoveryEntityKey.getKind().equals(path.getKey().getKind()) && discoveryEntityKey.getId()==path.getKey().getId())
+						ds.delete(discovery.getKey());
+				}
+				
+				// Right now discoveries are only used for paths. More may need to be handled later on.
+			}
+			
+			// Finally delete the location itself
+			ds.delete(locationKey);
+			
+			
+		}
+	}
+	
+	
+
+	/**
+	 * Determines the parent location for the given location. This is used for certain 
+	 * game mechanics that require a parent/child concept. For example, running will always cause you 
+	 * to run to the parent location.
+	 *  
+	 * @param ds
+	 * @param location
+	 * @return The location that is considered to be the parent of the given location.
+	 */
+	public CachedEntity getParentLocation(CachedDatastoreService ds, CachedEntity location)
+	{
+		if (location.getProperty("parentLocationKey")==null)
+		{
+			// FOR LAZY MIGRATION OF THE DATABASE, KEEP THIS PART ACTIVE.
+			List<CachedEntity> paths = getPathsByLocation(location.getKey());
+			
+			if (paths.isEmpty())
+				return null;	// This should never happen, but basically there is no escape from this combat site. Let's not throw here though.
+			
+			CachedEntity path = paths.get(0);
+			Key properLocationKey = null;
+			if (GameUtils.equals(path.getProperty("location1Key"), location.getKey()))
+				properLocationKey = (Key)path.getProperty("location2Key");
+			else
+				properLocationKey = (Key)path.getProperty("location1Key");
+			
+			location.setProperty("parentLocationKey", properLocationKey);
+			if (ds==null) ds = getDB();
+			ds.put(location);
+ 			
+			CachedEntity exitLocation = getEntity(properLocationKey);
+			
+			Logger.getLogger("GameFunctions").log(Level.SEVERE, "Parent location on a "+location.getProperty("type")+" was not set properly. - We decided to associate it."); 
+			
+			return exitLocation;
+		}
+		else
+		{
+			Key key = (Key)location.getProperty("parentLocationKey");
+			return getEntity(key);
+		}
+	}
+
+	
+	
+	
+	
+	/**
+	 * If we return true, it's because the escape was successful and the
+	 * character will have already been placed in the new location.
+	 * 
+	 * @param character
+	 * @param monster
+	 * @return
+	 * @throws UserErrorMessage 
+	 */
+	public boolean doCharacterAttemptEscape(CachedEntity characterLocation, CachedEntity character, CachedEntity monster) throws UserErrorMessage
+	{
+		CachedDatastoreService db = getDB();
+//		db.beginTransaction();
+		
+		try
+		{
+			String mode = (String)character.getProperty("mode");
+			
+			if (mode==null || mode.equals(ODPDBAccess.CHARACTER_MODE_COMBAT)==false)
+				throw new UserErrorMessage("Character must be in combat in order to attempt to escape.");
+			
+			if ("NPC".equals(monster.getProperty("type"))==false && isCharacterDefending(characterLocation, character))
+				throw new UserErrorMessage("You cannot escape while defending.");
+			
+			if (character.getProperty("partyCode")!=null && character.getProperty("partyCode").equals("")==false)
+			{
+				if ("TRUE".equals(character.getProperty("partyLeader"))==false)
+					throw new UserErrorMessage("You are not the party leader and therefore cannot choose to have the party run from the fight. If you want to run anyway, you will have to leave your party first.");
+			}
+
+			// Here we're flagging that a combat action took place so that the cron job in charge of ensuring combat keeps moving along
+			// doesn't automatically attack for us
+			if ("PC".equals(character.getProperty("type")) && "PC".equals(monster.getProperty("type")))
+				flagCharacterCombatAction(db, character);
+			
+			
+			Double characterDex = getCharacterDexterity(character);
+			Double monsterDex = getCharacterDexterity(monster);
+			
+			
+			Random rnd = new Random();
+			if (rnd.nextDouble()*characterDex>rnd.nextDouble()*monsterDex)
+			{
+				boolean defenceStructureAttack = "DefenceStructureAttack".equals(character.getProperty("combatType"));
+				List<CachedEntity> party = getParty(db, character);
+				
+				
+				
+				setPartiedField(party, character, "mode", CHARACTER_MODE_NORMAL);
+				setPartiedField(party, character, "combatant", null);
+				setPartiedField(party, character, "combatType", null);
+				putPartyMembersToDB(db, party, character);
+
+				// now notify the party members to refresh
+				if (party!=null)
+					for(CachedEntity member:party)
+						if (member.getKey().getId()!=character.getKey().getId())
+							sendNotification(db, member.getKey(), NotificationType.fullpageRefresh);
+				
+				
+				// Now we want to check if the monster should regain hitpoints or not
+				// Hitpoints should be regenerated if the monster is in a rest area 
+				CachedEntity monsterLocation = getEntity((Key)monster.getProperty("locationKey"));
+				
+				boolean isTerritoryCombat = false;
+				if (monsterLocation.getProperty("territoryKey")!=null || characterLocation.getProperty("territoryKey")!=null)
+					isTerritoryCombat = true;
+				
+				
+				if (monsterLocation!=null && (defenceStructureAttack || isTerritoryCombat))
+				{
+					Double hitpoints = (Double)monster.getProperty("hitpoints");
+					Double maxHitpoints = (Double)monster.getProperty("maxHitpoints");
+					if (hitpoints<maxHitpoints)
+						monster.setProperty("hitpoints", maxHitpoints);
+					
+					monster.setProperty("mode", CHARACTER_MODE_NORMAL);
+					monster.setProperty("combatant", null);
+					monster.setProperty("combatType", null);
+					
+					db.put(monster);
+					
+					sendNotification(db, monster.getKey(), NotificationType.fullpageRefresh);
+				}
+				else
+				{
+
+					// First lets take the monster out of combat
+					monster.setProperty("mode", CHARACTER_MODE_NORMAL);
+					monster.setProperty("combatant", null);
+					monster.setProperty("combatType", null);
+					
+					db.put(monster);					
+					
+					// Move locations! But only if we're in the same location as the monster..
+					if (GameUtils.equals(monster.getProperty("locationKey"), character.getProperty("locationKey")))
+					{
+						// Don't discover the path to the combat area, we shouldn't be able to remember how to get back there
+						// Take the path back to the source location. First we need to find the path..
+						List<CachedEntity> paths = getPathsByLocation((Key)character.getProperty("locationKey"));
+						CachedEntity parentLocation = getParentLocation(db, monsterLocation);
+					
+					
+						// Escape down the parent location if one exists
+						if (parentLocation!=null)
+						{
+							for(CachedEntity path:paths)
+								if (((Key)path.getProperty("location1Key")).getId()==parentLocation.getKey().getId() ||
+										((Key)path.getProperty("location2Key")).getId()==parentLocation.getKey().getId())
+								{
+									doCharacterTakePath(db, character, path, true);
+									return true;
+								}
+						}
+	
+						// Now shuffle the paths, looks like the parent location wasn't set right or at all
+						Collections.shuffle(paths);
+						
+						// Otherwise, escape down the first permanent location we find
+						for(CachedEntity path:paths)
+							if ("Permanent".equals(path.getProperty("type")))
+							{
+								doCharacterTakePath(db, character, path, true);
+								return true;
+							}
+						
+		
+						// If we're here, we didn't go down ANY path, so just go down the first one then...
+						doCharacterTakePath(db, character, paths.get(0), true);
+					}
+				}				
+
+				
+				
+				return true;
+			}
+			else
+			{
+				
+				
+//				db.commit();
+				return false;
+			}
+		}
+		finally
+		{
+//			db.rollbackIfActive();
+		}
+	}
+
+	
+	public String doMonsterCounterAttack(ODPAuthenticator auth, CachedEntity user, CachedEntity monster, CachedEntity character)
+	{
+		// Decide what weapon to use...
+		CachedEntity weaponToUse = null;
+		CachedEntity leftHand = null;
+		CachedEntity rightHand = null;
+		
+		if ((Double)monster.getProperty("hitpoints")>0)
+		{
+			leftHand = getEntity((Key)monster.getProperty("equipmentLeftHand"));
+			rightHand = getEntity((Key)monster.getProperty("equipmentRightHand"));
+			
+			// Here we're choosing the weapon to use as the left hand by default, if it is a weapon
+			if (leftHand!=null)
+			{
+				String itemType = (String)leftHand.getProperty("itemType");
+				if (itemType!=null && itemType.equals("Weapon"))
+					weaponToUse = leftHand;
+			}
+			
+			// Here we're getting the right hand item (if it's a weapon) and choosing a weapon if we're dual wielding
+			if (rightHand!=null)
+			{
+				String itemType = (String)rightHand.getProperty("itemType");
+				if (itemType!=null && itemType.equals("Weapon"))
+					if (weaponToUse!=null)
+					{
+						// Both hands have weapons, choose randomly between them by default or if automaticWeaponChoiceMethod==Random
+						if (GameUtils.enumEquals(monster.getProperty("automaticWeaponChoiceMethod"), AutomaticWeaponChoiceMethod.HighestDamage) || 
+								GameUtils.enumEquals(monster.getProperty("type"), CharacterType.PC) && (monster.getProperty("automaticWeaponChoiceMethod")==null || ((String)monster.getProperty("automaticWeaponChoiceMethod")).trim().equals("")))
+						{
+							Double maxDamageLeftHand = GameUtils.getWeaponMaxDamage(leftHand);
+							Double maxDamageRightHand = GameUtils.getWeaponMaxDamage(rightHand);
+							
+							if ((maxDamageLeftHand!=null && maxDamageRightHand!=null && maxDamageLeftHand>maxDamageRightHand))
+								weaponToUse = leftHand;
+							else
+								weaponToUse = rightHand;
+							
+						}
+						else
+						{
+							if (new Random().nextBoolean())
+								weaponToUse = leftHand;
+							else
+								weaponToUse = rightHand;
+						}
+					}
+					else
+						weaponToUse = rightHand;
+			}
+		
+			return doCharacterAttemptAttack(auth, user, monster, weaponToUse, character);
+		}		
+		else
+		{
+			return monster.getProperty("name")+" is dead.";
+		}
+	}
+	
+	public CachedEntity getCharacterStrongestWeapon(CachedEntity character)
+	{
+		CachedEntity result = null;
+		
+		CachedEntity leftHand = getEntity((Key)character.getProperty("equipmentLeftHand"));
+		CachedEntity rightHand = getEntity((Key)character.getProperty("equipmentRightHand"));
+		
+		if (leftHand!=null && rightHand!=null)
+		{
+			String leftType = (String)leftHand.getProperty("type");
+			String rightType = (String)rightHand.getProperty("type");
+			
+			if (leftType==null)leftType = "";
+			if (rightType==null) rightType = "";
+			
+			if (leftType.contains("Weapon") && rightType.contains("Weapon"))
+			{
+				// Now compare the two
+				long leftScore = GameUtils.determineQualityScore(leftHand.getProperties());
+				long rightScore = GameUtils.determineQualityScore(rightHand.getProperties());
+				if (leftScore>rightScore)
+					result = leftHand;
+				else
+					result = rightHand;
+			}
+			else if (leftType.contains("Weapon"))
+				result = leftHand;
+			else if (rightType.contains("Weapon"))
+				result = rightHand;
+		}
+		
+		return result;
+	}
+
 	
 }

--- a/Initium-Odp/src/com/universeprojects/miniup/server/ODPDBAccess.java
+++ b/Initium-Odp/src/com/universeprojects/miniup/server/ODPDBAccess.java
@@ -14,11 +14,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
+import java.util.UUID;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
+
+import org.datanucleus.util.StringUtils;
 
 import com.google.appengine.api.datastore.Cursor;
 import com.google.appengine.api.datastore.EntityNotFoundException;
@@ -4805,72 +4808,48 @@ public class ODPDBAccess
 		if ("FromLocation2Only".equals(forceOneWay) && currentLocationKey.getId() == pathLocation1Key.getId())
 			throw new UserErrorMessage("You cannot take this path.");
 			
-		boolean isInParty = true;
-		if (character.getProperty("partyCode")==null || character.getProperty("partyCode").equals(""))
-			isInParty = false;
+		boolean isInParty = StringUtils.notEmpty((String) character.getProperty("partyCode"));
 
-		if (destination.getProperty("ownerKey")!=null)
-		{
-			if (isInParty) {
-				//We check to see if all members of the party have access by default to enter
-				//the owned housing.  If not, we reject.
-				List<CachedEntity> partyMembers = getParty(db, character);
-				List<Key> partyGroups = new ArrayList<Key>();
-				List<Key> partyUsers = new ArrayList<Key>();
+		Key ownerKey = (Key) destination.getProperty("ownerKey");
+		if (ownerKey != null) {
+			// Check to see if all members of the party have access to enter owned housing.
+			List<CachedEntity> partyMembers = getParty(db, character);
+			if (partyMembers == null) partyMembers = Collections.singletonList(character); // You are the only party member
+
+			if("Group".equals(ownerKey.getKind())){
+				Set<String> groupKeySet = new HashSet<String>(); // Sets guarantee one and only one entry per unique value
+				List<String> isActiveInGroupStatusList = Arrays.asList(GroupStatus.Admin.name(), GroupStatus.Member.name()); // Wish we had streaming to build this appropriately
 				for(CachedEntity partyMember: partyMembers) {
-					//Removes those who have just applied
-					String groupStatus = (String)character.getProperty("groupStatus");
-					if(("Member".equals(groupStatus)==false && "Admin".equals(groupStatus)==false)) {
-						partyGroups.add(null);
-					} else {
-						partyGroups.add((Key)partyMember.getProperty("groupKey"));
-					}
-					partyUsers.add((Key)partyMember.getProperty("userKey"));
+					//Removes those who have just applied or have been kicked
+					boolean belongstoGroup = isActiveInGroupStatusList.contains(partyMember.getProperty("groupStatus"));
+					Key groupKey = (Key) partyMember.getProperty("groupKey"); // This should always be here if they belong to a group
+					String mapKey = belongstoGroup ? groupKey.toString() : UUID.randomUUID().toString(); // random UUID to ensure uniqueness
+					groupKeySet.add(mapKey);
 				}
-				Key ownerKey = (Key)destination.getProperty("ownerKey");
-				if(ownerKey.getKind().equals("Group")){
-					//iterates through the list of groups that the party members belong to.
-					//if there are any differences, set the flag to false
-					boolean allInSameGroup = true;
-					for(int i = 0; i < partyGroups.size() - 1; i++) {
-						if(!GameUtils.equals(partyGroups.get(i), partyGroups.get(i+1))){
-							allInSameGroup = false;
-							break;
-						}
-					}
-					if(!allInSameGroup && !GameUtils.equals(ownerKey, partyGroups.get(0))) {
-						throw new UserErrorMessage("You cannot enter a group owned house in a party unless all members of the party are part of that group.");
-					}
-				} else if(ownerKey.getKind().equals("User")) {
-					//iterates through the list of accounts that the party members belong to.
-					//if there are any differences, set the flag to false
-					boolean allOfSameUser = true;
-					for(int i = 0; i < partyUsers.size() - 1; i++) {
-						if(!GameUtils.equals(partyUsers.get(i), partyUsers.get(i+1))){
-							allOfSameUser = false;
-							break;
-						}
-					}
-					if(!allOfSameUser && !GameUtils.equals(ownerKey, partyUsers.get(0))) {
-						throw new UserErrorMessage("You cannot enter a player owned house in a party unless all members of the party are characters of that player.");
+
+				if(!groupKeySet.contains(ownerKey.toString()) || groupKeySet.size() != 1) { // Check for non-matching keys
+					throw new UserErrorMessage(String.format("You cannot enter a group owned house unless %s.", partyMembers.size() > 1 ? "all members of your party are members of the group" : "you are a member of the group"));
+				}
+			} else if("User".equals(ownerKey.getKind())) {
+				boolean ownerIsPresent = false;
+				Key pathOwner = (Key) path.getProperty("ownerKey");
+				for (CachedEntity partyMember : partyMembers) {
+					if (GameUtils.equals(pathOwner, partyMember.getProperty("ownerKey"))) {
+						ownerIsPresent = true;
+						break;
 					}
 				}
-			}
-				
-			
-			Key ownerKey = (Key)destination.getProperty("ownerKey");
-			if (ownerKey.getKind().equals("Group"))
-			{
-				String groupStatus = (String)character.getProperty("groupStatus");
-				if (character.getProperty("groupKey")==null || 
-						ownerKey.getId() != ((Key)character.getProperty("groupKey")).getId() || 
-						("Member".equals(groupStatus)==false && "Admin".equals(groupStatus)==false))
-					throw new UserErrorMessage("You cannot enter a group-owned house unless you are part of that group.");
+
+				if (!ownerIsPresent) {
+					throw new UserErrorMessage(String.format("You cannot enter a player owned house unless %s.", partyMembers.size() > 1 ? "the owner is a character in your party" : "you are the owner"));
+				}
+			} else {
+				// TODO - Exception? If we can't determine the owner type; the character will be allowed to take the path. 
 			}
 		}
 		
 		MovementService movementService = new MovementService(this);
-		
+
 		// Check if this property is locked and if so, if we have the key to enter it...
 		movementService.checkForLocks(character, path, destinationKey);
 		

--- a/Initium-Odp/src/com/universeprojects/miniup/server/commands/CommandDogeCoinsCollectFromCharacter.java
+++ b/Initium-Odp/src/com/universeprojects/miniup/server/commands/CommandDogeCoinsCollectFromCharacter.java
@@ -10,7 +10,7 @@ import com.universeprojects.cacheddatastore.CachedDatastoreService;
 import com.universeprojects.cacheddatastore.CachedEntity;
 import com.universeprojects.miniup.server.GameUtils;
 import com.universeprojects.miniup.server.ODPDBAccess;
-import com.universeprojects.miniup.server.commands.framework.Command;
+import com.universeprojects.miniup.server.commands.framework.TransactionCommand;
 import com.universeprojects.miniup.server.commands.framework.UserErrorMessage;
 import com.universeprojects.miniup.server.services.ContainerService;
 import com.universeprojects.miniup.server.services.MainPageUpdateService;
@@ -24,17 +24,26 @@ import com.universeprojects.miniup.server.services.MainPageUpdateService;
  * @author SPFiredrake
  *
  */
-public class CommandDogeCoinsCollectFromCharacter extends Command {
+public class CommandDogeCoinsCollectFromCharacter extends TransactionCommand {
 
 	public CommandDogeCoinsCollectFromCharacter(ODPDBAccess db, HttpServletRequest request, HttpServletResponse response) {
 		super(db, request, response);
 	}
 	
+
 	@Override
-	public void run(Map<String, String> parameters) throws UserErrorMessage {
+	public void runBeforeTransaction(Map<String, String> parameters) throws UserErrorMessage
+	{
+		
+	}
+
+	@Override
+	public void runInsideTransaction(Map<String, String> parameters) throws UserErrorMessage
+	{
 		ODPDBAccess db = getDB();
 		CachedDatastoreService ds = getDS();
 		CachedEntity character = db.getCurrentCharacter();
+		character = ds.refetch(character);
 
 		long charId = tryParseId(parameters, "characterId");
 		CachedEntity collectFromCharacter = db.getEntity("Character", charId);
@@ -66,6 +75,13 @@ public class CommandDogeCoinsCollectFromCharacter extends Command {
 		
 		MainPageUpdateService service = new MainPageUpdateService(db, db.getCurrentUser(), character, null, this);
 		service.updateMoney();
+		
+	}
+
+	@Override
+	public void runAfterTransaction(Map<String, String> parameters) throws UserErrorMessage
+	{
+		
 	}
 
 }

--- a/Initium-Odp/src/com/universeprojects/miniup/server/commands/CommandDogeCoinsCollectFromItem.java
+++ b/Initium-Odp/src/com/universeprojects/miniup/server/commands/CommandDogeCoinsCollectFromItem.java
@@ -41,6 +41,7 @@ public class CommandDogeCoinsCollectFromItem extends TransactionCommand {
 		ODPDBAccess db = getDB();
 		CachedDatastoreService ds = getDS();
 		CachedEntity character = db.getCurrentCharacter();
+		character = ds.refetch(character);
 		
 		long itemId = tryParseId(parameters, "itemId");
 		CachedEntity item = db.getEntity("Item", itemId);

--- a/Initium-Odp/src/com/universeprojects/miniup/server/commands/CommandDogeCoinsDepositToItem.java
+++ b/Initium-Odp/src/com/universeprojects/miniup/server/commands/CommandDogeCoinsDepositToItem.java
@@ -9,7 +9,7 @@ import com.google.appengine.api.datastore.Key;
 import com.universeprojects.cacheddatastore.CachedDatastoreService;
 import com.universeprojects.cacheddatastore.CachedEntity;
 import com.universeprojects.miniup.server.ODPDBAccess;
-import com.universeprojects.miniup.server.commands.framework.Command;
+import com.universeprojects.miniup.server.commands.framework.TransactionCommand;
 import com.universeprojects.miniup.server.commands.framework.UserErrorMessage;
 import com.universeprojects.miniup.server.services.ContainerService;
 import com.universeprojects.miniup.server.services.MainPageUpdateService;
@@ -24,17 +24,25 @@ import com.universeprojects.miniup.server.services.MainPageUpdateService;
  * @author SPFiredrake
  *
  */
-public class CommandDogeCoinsDepositToItem extends Command {
+public class CommandDogeCoinsDepositToItem extends TransactionCommand {
 
 	public CommandDogeCoinsDepositToItem(ODPDBAccess db, HttpServletRequest request, HttpServletResponse response) {
 		super(db, request, response);
 	}
 	
 	@Override
-	public void run(Map<String, String> parameters) throws UserErrorMessage {
+	public void runBeforeTransaction(Map<String, String> parameters) throws UserErrorMessage
+	{
+		
+	}
+
+	@Override
+	public void runInsideTransaction(Map<String, String> parameters) throws UserErrorMessage
+	{
 		ODPDBAccess db = getDB();
 		CachedDatastoreService ds = getDS();
 		CachedEntity character = db.getCurrentCharacter();
+		character = ds.refetch(character);
 		
 		long itemId = tryParseId(parameters, "itemId");
 		CachedEntity item = db.getEntity("Item", itemId);
@@ -67,7 +75,13 @@ public class CommandDogeCoinsDepositToItem extends Command {
 		ds.put(item);
 		
 		MainPageUpdateService service = new MainPageUpdateService(db, db.getCurrentUser(), character, null, this);
-		service.updateMoney();
+		service.updateMoney();		
+	}
+
+	@Override
+	public void runAfterTransaction(Map<String, String> parameters) throws UserErrorMessage
+	{
+		
 	}
 
 }

--- a/Initium-Odp/src/com/universeprojects/miniup/server/services/MovementService.java
+++ b/Initium-Odp/src/com/universeprojects/miniup/server/services/MovementService.java
@@ -8,14 +8,18 @@ import com.google.appengine.api.datastore.Query.FilterOperator;
 import com.google.appengine.api.datastore.Query.FilterPredicate;
 import com.universeprojects.cacheddatastore.CachedDatastoreService;
 import com.universeprojects.cacheddatastore.CachedEntity;
+import com.universeprojects.cacheddatastore.QueryHelper;
 import com.universeprojects.miniup.server.GameUtils;
 import com.universeprojects.miniup.server.ODPDBAccess;
 import com.universeprojects.miniup.server.commands.framework.UserErrorMessage;
 
 public class MovementService extends Service {
-	
+
+	private QueryHelper queryHelper;
+
 	public MovementService(ODPDBAccess db) {
 		super(db);
+		this.queryHelper = new QueryHelper(super.db.getDB());
 	}
 	
 	public void checkForLocks(CachedEntity character, CachedEntity pathToTake, Key destinationLocationKey) throws UserErrorMessage
@@ -61,5 +65,15 @@ public class MovementService extends Service {
 		
 		return (matchingKeys > 0);
 	}
-	
+
+	/**
+	 * Returns true if the character has a Discovery for the path.
+	 * 
+	 * @param characterKey
+	 * @param pathKey
+	 * @return
+	 */
+	public boolean isPathDiscovered(Key characterKey, Key pathKey) {
+		return queryHelper.getFilteredList_Count("Discovery", "characterKey", FilterOperator.EQUAL, characterKey, "entityKey", FilterOperator.EQUAL, pathKey) > 0;
+	}
 }

--- a/Initium-Odp/test/com/universeprojects/miniup/server/ODPDBAccessTest.java
+++ b/Initium-Odp/test/com/universeprojects/miniup/server/ODPDBAccessTest.java
@@ -1,0 +1,468 @@
+package com.universeprojects.miniup.server;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import com.google.appengine.api.datastore.Key;
+import com.google.appengine.api.datastore.KeyFactory;
+import com.google.appengine.tools.development.testing.LocalDatastoreServiceTestConfig;
+import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
+import com.universeprojects.cacheddatastore.CachedDatastoreService;
+import com.universeprojects.cacheddatastore.CachedEntity;
+import com.universeprojects.miniup.server.ODPDBAccess.GroupStatus;
+import com.universeprojects.miniup.server.commands.framework.UserErrorMessage;
+
+import helper.utilities.HttpServletRequestImpl;
+
+public class ODPDBAccessTest {
+
+	private final LocalServiceTestHelper helper = new LocalServiceTestHelper(new LocalDatastoreServiceTestConfig());
+
+	private ODPDBAccess testObj;
+
+	@Rule
+	public ExpectedException expectedException = ExpectedException.none();
+
+	@Before
+	public void before() {
+		helper.setUp();
+		CachedDatastoreService.disableRemoteAPI();
+		testObj = new ODPDBAccess(new HttpServletRequestImpl());
+	}
+
+	@After
+	public void after() {
+		helper.tearDown();
+	}
+
+	@Test
+	public void doCharacterTakePath_userOwner_noParty_newDiscovery() throws Exception { // Single character happy path
+		CachedEntity user = new CachedEntity("User");
+		testObj.getDB().put(user);
+		CachedEntity character = new CachedEntity("Character");
+		Key currentLocationKey = KeyFactory.createKey("locationKey", 1);
+		character.setProperty("locationKey", currentLocationKey);
+		character.setProperty("ownerKey", user.getKey());
+		testObj.getDB().put(character);
+		CachedEntity destinationEntity = new CachedEntity("Location");
+		destinationEntity.setProperty("ownerKey", user.getKey());
+		testObj.getDB().put(destinationEntity);
+		CachedEntity path = new CachedEntity("Path");
+		path.setProperty("location1Key", currentLocationKey);
+		path.setProperty("location2Key", destinationEntity.getKey());
+		path.setProperty("ownerKey", user.getKey());
+		testObj.getDB().put(path);
+
+		CachedEntity actualDestination = testObj.doCharacterTakePath(testObj.getDB(), character, path , false);
+
+		assertEquals(destinationEntity, actualDestination);
+		assertEquals(destinationEntity.getKey(), testObj.getDB().get(character.getKey()).getProperty("locationKey"));
+		CachedEntity discovery = testObj.getDiscoveryByEntity(character.getKey(), path.getKey()); // TODO getDiscoveryByEntity needs tests and needs to go to a DAO
+		assertEquals(character.getKey(), discovery.getProperty("characterKey"));
+		assertEquals(path.getKey(), discovery.getProperty("entityKey"));
+		assertEquals(path.getKind(), discovery.getProperty("kind"));
+		assertEquals(currentLocationKey, discovery.getProperty("location1Key"));
+		assertEquals(destinationEntity.getKey(), discovery.getProperty("location2Key"));
+	}
+
+	@Test
+	public void doCharacterTakePath_noParty_userNotOwner() throws Exception { // Single character not the owner
+		expectedException.expect(UserErrorMessage.class);
+		expectedException.expectMessage("You cannot enter a player owned house unless you are the owner."); // TODO - move these exceptions to properties
+
+		CachedEntity user = new CachedEntity("User");
+		testObj.getDB().put(user);
+		CachedEntity character = new CachedEntity("Character");
+		Key currentLocationKey = KeyFactory.createKey("locationKey", 1);
+		character.setProperty("locationKey", currentLocationKey);
+		character.setProperty("ownerKey", user.getKey());
+		testObj.getDB().put(character);
+		CachedEntity destinationEntity = new CachedEntity("Location");
+		destinationEntity.setProperty("ownerKey", user.getKey());
+		testObj.getDB().put(destinationEntity);
+		CachedEntity path = new CachedEntity("Path");
+		path.setProperty("location1Key", currentLocationKey);
+		path.setProperty("location2Key", destinationEntity.getKey());
+		CachedEntity nonMatchingUser = new CachedEntity("User");
+		testObj.getDB().put(user);
+		path.setProperty("ownerKey", nonMatchingUser.getKey());
+		testObj.getDB().put(path);
+
+		testObj.doCharacterTakePath(testObj.getDB(), character, path , false);
+	}
+
+	@Test
+	public void doCharacterTakePath_userOwner_inParty_sameUser_isOwner_isLeader() throws Exception { // Two user characters, happy path
+		CachedEntity user = new CachedEntity("User");
+		testObj.getDB().put(user);
+		CachedEntity character1 = new CachedEntity("Character");
+		Key currentLocationKey = KeyFactory.createKey("locationKey", 1);
+		character1.setProperty("locationKey", currentLocationKey);
+		String partyCode = "partyCode";
+		character1.setProperty("partyCode", partyCode);
+		character1.setProperty("ownerKey", user.getKey());
+		character1.setProperty("partyLeader", "TRUE");
+		testObj.getDB().put(character1);
+		CachedEntity character2 = new CachedEntity("Character");
+		character2.setProperty("locationKey", currentLocationKey);
+		character2.setProperty("partyCode", partyCode);
+		character2.setProperty("ownerKey", user.getKey());
+		testObj.getDB().put(character2);
+		CachedEntity destinationEntity = new CachedEntity("Location");
+		destinationEntity.setProperty("ownerKey", user.getKey());
+		testObj.getDB().put(destinationEntity);
+		CachedEntity path = new CachedEntity("Path");
+		path.setProperty("location1Key", currentLocationKey);
+		path.setProperty("location2Key", destinationEntity.getKey());
+		path.setProperty("ownerKey", user.getKey());
+		testObj.getDB().put(path);
+		
+		CachedEntity actualDestination = testObj.doCharacterTakePath(testObj.getDB(), character1, path , false);
+		
+		assertEquals(destinationEntity, actualDestination);
+		assertEquals(destinationEntity.getKey(), testObj.getDB().get(character1.getKey()).getProperty("locationKey"));
+		CachedEntity discovery = testObj.getDiscoveryByEntity(character1.getKey(), path.getKey());
+		assertEquals(character1.getKey(), discovery.getProperty("characterKey"));
+		assertEquals(path.getKey(), discovery.getProperty("entityKey"));
+		assertEquals(path.getKind(), discovery.getProperty("kind"));
+		assertEquals(currentLocationKey, discovery.getProperty("location1Key"));
+		assertEquals(destinationEntity.getKey(), discovery.getProperty("location2Key"));
+	}
+
+	@Test
+	public void doCharacterTakePath_userOwner_inParty_noOwner_isLeader() throws Exception { // Two characters of different users, one is owner
+		expectedException.expect(UserErrorMessage.class);
+		expectedException.expectMessage("You cannot enter a player owned house unless the owner is a character in your party."); // TODO - move these exceptions to properties
+
+		CachedEntity user1 = new CachedEntity("User");
+		testObj.getDB().put(user1);
+		CachedEntity character1 = new CachedEntity("Character");
+		Key currentLocationKey = KeyFactory.createKey("locationKey", 1);
+		character1.setProperty("locationKey", currentLocationKey);
+		String partyCode = "partyCode";
+		character1.setProperty("partyCode", partyCode);
+		character1.setProperty("ownerKey", user1.getKey());
+		character1.setProperty("partyLeader", "TRUE");
+		testObj.getDB().put(character1);
+		CachedEntity user2 = new CachedEntity("User");
+		testObj.getDB().put(user2);
+		CachedEntity character2 = new CachedEntity("Character");
+		character2.setProperty("locationKey", currentLocationKey);
+		character2.setProperty("partyCode", partyCode);
+		character2.setProperty("ownerKey", user2.getKey());
+		testObj.getDB().put(character2);
+		CachedEntity user3 = new CachedEntity("User");
+		testObj.getDB().put(user3);
+		CachedEntity destinationEntity = new CachedEntity("Location");
+		destinationEntity.setProperty("ownerKey", user3.getKey());
+		testObj.getDB().put(destinationEntity);
+		CachedEntity path = new CachedEntity("Path");
+		path.setProperty("location1Key", currentLocationKey);
+		path.setProperty("location2Key", destinationEntity.getKey());
+		path.setProperty("ownerKey", user3.getKey());
+		testObj.getDB().put(path);
+		
+		testObj.doCharacterTakePath(testObj.getDB(), character1, path , false);
+	}
+
+	@Test
+	public void doCharacterTakePath_userOwner_inParty_sameUser_isOwner_isNotLeader() throws Exception { // Two user characters and is the owner, but not using the party leader character
+		expectedException.expect(UserErrorMessage.class);
+		expectedException.expectMessage("You cannot move the party because you're not the party leader."); // TODO - move these exceptions to properties
+
+		CachedEntity user = new CachedEntity("User");
+		testObj.getDB().put(user);
+		CachedEntity character1 = new CachedEntity("Character");
+		Key currentLocationKey = KeyFactory.createKey("locationKey", 1);
+		character1.setProperty("locationKey", currentLocationKey);
+		String partyCode = "partyCode";
+		character1.setProperty("partyCode", partyCode);
+		character1.setProperty("ownerKey", user.getKey());
+		character1.setProperty("partyLeader", "TRUE");
+		testObj.getDB().put(character1);
+		CachedEntity character2 = new CachedEntity("Character");
+		character2.setProperty("locationKey", currentLocationKey);
+		character2.setProperty("partyCode", partyCode);
+		character2.setProperty("ownerKey", user.getKey());
+		testObj.getDB().put(character2);
+		CachedEntity destinationEntity = new CachedEntity("Location");
+		destinationEntity.setProperty("ownerKey", user.getKey());
+		testObj.getDB().put(destinationEntity);
+		CachedEntity path = new CachedEntity("Path");
+		path.setProperty("location1Key", currentLocationKey);
+		path.setProperty("location2Key", destinationEntity.getKey());
+		path.setProperty("ownerKey", user.getKey());
+		testObj.getDB().put(path);
+		
+		testObj.doCharacterTakePath(testObj.getDB(), character2, path , false);
+	}
+
+	@Test
+	public void doCharacterTakePath_groupOwner_singleChar_inGroupAsAdmin() throws Exception {
+		CachedEntity group = new CachedEntity("Group");
+		testObj.getDB().put(group);
+		CachedEntity user = new CachedEntity("User");
+		testObj.getDB().put(user);
+		CachedEntity character = new CachedEntity("Character");
+		Key currentLocationKey = KeyFactory.createKey("locationKey", 1);
+		character.setProperty("locationKey", currentLocationKey);
+		character.setProperty("ownerKey", user.getKey());
+		character.setProperty("groupKey", group.getKey());
+		character.setProperty("groupStatus", GroupStatus.Admin.name());
+		testObj.getDB().put(character);
+		CachedEntity destinationEntity = new CachedEntity("Location");
+		destinationEntity.setProperty("ownerKey", group.getKey());
+		testObj.getDB().put(destinationEntity);
+		CachedEntity path = new CachedEntity("Path");
+		path.setProperty("location1Key", currentLocationKey);
+		path.setProperty("location2Key", destinationEntity.getKey());
+		path.setProperty("ownerKey", group.getKey());
+		testObj.getDB().put(path);
+
+		CachedEntity actualDestination = testObj.doCharacterTakePath(testObj.getDB(), character, path , false);
+
+		assertEquals(destinationEntity, actualDestination);
+		assertEquals(destinationEntity.getKey(), testObj.getDB().get(character.getKey()).getProperty("locationKey"));
+		CachedEntity discovery = testObj.getDiscoveryByEntity(character.getKey(), path.getKey()); // TODO getDiscoveryByEntity needs tests and needs to go to a DAO
+		assertEquals(character.getKey(), discovery.getProperty("characterKey"));
+		assertEquals(path.getKey(), discovery.getProperty("entityKey"));
+		assertEquals(path.getKind(), discovery.getProperty("kind"));
+		assertEquals(currentLocationKey, discovery.getProperty("location1Key"));
+		assertEquals(destinationEntity.getKey(), discovery.getProperty("location2Key"));
+	}
+
+	@Test
+	public void doCharacterTakePath_groupOwner_singleChar_inGroupAsMember() throws Exception {
+		CachedEntity group = new CachedEntity("Group");
+		testObj.getDB().put(group);
+		CachedEntity user = new CachedEntity("User");
+		testObj.getDB().put(user);
+		CachedEntity character = new CachedEntity("Character");
+		Key currentLocationKey = KeyFactory.createKey("locationKey", 1);
+		character.setProperty("locationKey", currentLocationKey);
+		character.setProperty("ownerKey", user.getKey());
+		character.setProperty("groupKey", group.getKey());
+		character.setProperty("groupStatus", GroupStatus.Member.name());
+		testObj.getDB().put(character);
+		CachedEntity destinationEntity = new CachedEntity("Location");
+		destinationEntity.setProperty("ownerKey", group.getKey());
+		testObj.getDB().put(destinationEntity);
+		CachedEntity path = new CachedEntity("Path");
+		path.setProperty("location1Key", currentLocationKey);
+		path.setProperty("location2Key", destinationEntity.getKey());
+		path.setProperty("ownerKey", group.getKey());
+		testObj.getDB().put(path);
+
+		CachedEntity actualDestination = testObj.doCharacterTakePath(testObj.getDB(), character, path , false);
+
+		assertEquals(destinationEntity, actualDestination);
+		assertEquals(destinationEntity.getKey(), testObj.getDB().get(character.getKey()).getProperty("locationKey"));
+		CachedEntity discovery = testObj.getDiscoveryByEntity(character.getKey(), path.getKey()); // TODO getDiscoveryByEntity needs tests and needs to go to a DAO
+		assertEquals(character.getKey(), discovery.getProperty("characterKey"));
+		assertEquals(path.getKey(), discovery.getProperty("entityKey"));
+		assertEquals(path.getKind(), discovery.getProperty("kind"));
+		assertEquals(currentLocationKey, discovery.getProperty("location1Key"));
+		assertEquals(destinationEntity.getKey(), discovery.getProperty("location2Key"));
+	}
+
+	@Test
+	public void doCharacterTakePath_groupOwner_twoChars_inGroup() throws Exception {
+		CachedEntity group = new CachedEntity("Group");
+		testObj.getDB().put(group);
+		CachedEntity user = new CachedEntity("User");
+		testObj.getDB().put(user);
+		CachedEntity character1 = new CachedEntity("Character");
+		Key currentLocationKey = KeyFactory.createKey("locationKey", 1);
+		character1.setProperty("locationKey", currentLocationKey);
+		character1.setProperty("ownerKey", user.getKey());
+		character1.setProperty("groupKey", group.getKey());
+		character1.setProperty("groupStatus", GroupStatus.Member.name());
+		String partyCode = "partyCode";
+		character1.setProperty("partyCode", partyCode);
+		character1.setProperty("partyLeader", "TRUE");
+		testObj.getDB().put(character1);
+		CachedEntity character2 = new CachedEntity("Character");
+		character2.setProperty("locationKey", currentLocationKey);
+		character2.setProperty("ownerKey", user.getKey());
+		character2.setProperty("partyCode", partyCode);
+		character2.setProperty("groupKey", group.getKey());
+		character2.setProperty("groupStatus", GroupStatus.Member.name());
+		testObj.getDB().put(character2);
+		CachedEntity destinationEntity = new CachedEntity("Location");
+		destinationEntity.setProperty("ownerKey", group.getKey());
+		testObj.getDB().put(destinationEntity);
+		CachedEntity path = new CachedEntity("Path");
+		path.setProperty("location1Key", currentLocationKey);
+		path.setProperty("location2Key", destinationEntity.getKey());
+		path.setProperty("ownerKey", group.getKey());
+		testObj.getDB().put(path);
+		
+		CachedEntity actualDestination = testObj.doCharacterTakePath(testObj.getDB(), character1, path , false);
+		
+		assertEquals(destinationEntity, actualDestination);
+		assertEquals(destinationEntity.getKey(), testObj.getDB().get(character1.getKey()).getProperty("locationKey"));
+		CachedEntity discovery = testObj.getDiscoveryByEntity(character1.getKey(), path.getKey()); // TODO getDiscoveryByEntity needs tests and needs to go to a DAO
+		assertEquals(character1.getKey(), discovery.getProperty("characterKey"));
+		assertEquals(path.getKey(), discovery.getProperty("entityKey"));
+		assertEquals(path.getKind(), discovery.getProperty("kind"));
+		assertEquals(currentLocationKey, discovery.getProperty("location1Key"));
+		assertEquals(destinationEntity.getKey(), discovery.getProperty("location2Key"));
+	}
+
+	@Test
+	public void doCharacterTakePath_groupOwner_twoChar_oneInGroupAsAdmin_otherNoGroup_asAdmin() throws Exception {
+		expectedException.expect(UserErrorMessage.class);
+		expectedException.expectMessage("You cannot enter a group owned house unless all members of your party are members of the group."); // TODO - move these exceptions to properties
+
+		CachedEntity group = new CachedEntity("Group");
+		testObj.getDB().put(group);
+		CachedEntity user = new CachedEntity("User");
+		testObj.getDB().put(user);
+		CachedEntity character1 = new CachedEntity("Character");
+		Key currentLocationKey = KeyFactory.createKey("locationKey", 1);
+		character1.setProperty("locationKey", currentLocationKey);
+		character1.setProperty("ownerKey", user.getKey());
+		character1.setProperty("groupKey", group.getKey());
+		character1.setProperty("groupStatus", GroupStatus.Admin.name());
+		String partyCode = "partyCode";
+		character1.setProperty("partyCode", partyCode);
+		character1.setProperty("partyLeader", "TRUE");
+		testObj.getDB().put(character1);
+		CachedEntity character2 = new CachedEntity("Character");
+		character2.setProperty("locationKey", currentLocationKey);
+		character2.setProperty("ownerKey", user.getKey());
+		character2.setProperty("partyCode", partyCode);
+		testObj.getDB().put(character2);
+		CachedEntity destinationEntity = new CachedEntity("Location");
+		destinationEntity.setProperty("ownerKey", group.getKey());
+		testObj.getDB().put(destinationEntity);
+		CachedEntity path = new CachedEntity("Path");
+		path.setProperty("location1Key", currentLocationKey);
+		path.setProperty("location2Key", destinationEntity.getKey());
+		path.setProperty("ownerKey", group.getKey());
+		testObj.getDB().put(path);
+
+		testObj.doCharacterTakePath(testObj.getDB(), character1, path , false);
+	}
+
+	@Test
+	public void doCharacterTakePath_groupOwner_twoChar_oneInGroupAsAdmin_otherNoGroup_asNoGroupChar() throws Exception {
+		expectedException.expect(UserErrorMessage.class);
+		expectedException.expectMessage("You cannot enter a group owned house unless all members of your party are members of the group."); // TODO - move these exceptions to properties
+
+		CachedEntity group = new CachedEntity("Group");
+		testObj.getDB().put(group);
+		CachedEntity user = new CachedEntity("User");
+		testObj.getDB().put(user);
+		CachedEntity character1 = new CachedEntity("Character");
+		Key currentLocationKey = KeyFactory.createKey("locationKey", 1);
+		character1.setProperty("locationKey", currentLocationKey);
+		character1.setProperty("ownerKey", user.getKey());
+		character1.setProperty("groupKey", group.getKey());
+		character1.setProperty("groupStatus", GroupStatus.Admin.name());
+		String partyCode = "partyCode";
+		character1.setProperty("partyCode", partyCode);
+		testObj.getDB().put(character1);
+		CachedEntity character2 = new CachedEntity("Character");
+		character2.setProperty("locationKey", currentLocationKey);
+		character2.setProperty("ownerKey", user.getKey());
+		character2.setProperty("partyCode", partyCode);
+		character1.setProperty("partyLeader", "TRUE");
+		testObj.getDB().put(character2);
+		CachedEntity destinationEntity = new CachedEntity("Location");
+		destinationEntity.setProperty("ownerKey", group.getKey());
+		testObj.getDB().put(destinationEntity);
+		CachedEntity path = new CachedEntity("Path");
+		path.setProperty("location1Key", currentLocationKey);
+		path.setProperty("location2Key", destinationEntity.getKey());
+		path.setProperty("ownerKey", group.getKey());
+		testObj.getDB().put(path);
+
+		testObj.doCharacterTakePath(testObj.getDB(), character2, path , false);
+	}
+
+	@Test
+	public void doCharacterTakePath_groupOwner_twoChar_oneInGroupAsAdmin_otherDifferentGroup_asAdmin() throws Exception {
+		expectedException.expect(UserErrorMessage.class);
+		expectedException.expectMessage("You cannot enter a group owned house unless all members of your party are members of the group."); // TODO - move these exceptions to properties
+
+		CachedEntity group1 = new CachedEntity("Group");
+		testObj.getDB().put(group1);
+		CachedEntity group2 = new CachedEntity("Group");
+		testObj.getDB().put(group2);
+		CachedEntity user = new CachedEntity("User");
+		testObj.getDB().put(user);
+		CachedEntity character1 = new CachedEntity("Character");
+		Key currentLocationKey = KeyFactory.createKey("locationKey", 1);
+		character1.setProperty("locationKey", currentLocationKey);
+		character1.setProperty("ownerKey", user.getKey());
+		character1.setProperty("groupKey", group1.getKey());
+		character1.setProperty("groupStatus", GroupStatus.Admin.name());
+		String partyCode = "partyCode";
+		character1.setProperty("partyCode", partyCode);
+		character1.setProperty("partyLeader", "TRUE");
+		testObj.getDB().put(character1);
+		CachedEntity character2 = new CachedEntity("Character");
+		character2.setProperty("locationKey", currentLocationKey);
+		character2.setProperty("ownerKey", user.getKey());
+		character2.setProperty("partyCode", partyCode);
+		character2.setProperty("groupKey", group2.getKey());
+		character2.setProperty("groupStatus", GroupStatus.Member.name());
+		testObj.getDB().put(character2);
+		CachedEntity destinationEntity = new CachedEntity("Location");
+		destinationEntity.setProperty("ownerKey", group1.getKey());
+		testObj.getDB().put(destinationEntity);
+		CachedEntity path = new CachedEntity("Path");
+		path.setProperty("location1Key", currentLocationKey);
+		path.setProperty("location2Key", destinationEntity.getKey());
+		path.setProperty("ownerKey", group1.getKey());
+		testObj.getDB().put(path);
+
+		testObj.doCharacterTakePath(testObj.getDB(), character1, path , false);
+	}
+
+	@Test
+	public void doCharacterTakePath_groupOwner_twoChar_oneInGroupAsAdmin_otherDifferentGroup_asOther() throws Exception {
+		expectedException.expect(UserErrorMessage.class);
+		expectedException.expectMessage("You cannot enter a group owned house unless all members of your party are members of the group."); // TODO - move these exceptions to properties
+		
+		CachedEntity group1 = new CachedEntity("Group");
+		testObj.getDB().put(group1);
+		CachedEntity group2 = new CachedEntity("Group");
+		testObj.getDB().put(group2);
+		CachedEntity user = new CachedEntity("User");
+		testObj.getDB().put(user);
+		CachedEntity character1 = new CachedEntity("Character");
+		Key currentLocationKey = KeyFactory.createKey("locationKey", 1);
+		character1.setProperty("locationKey", currentLocationKey);
+		character1.setProperty("ownerKey", user.getKey());
+		character1.setProperty("groupKey", group1.getKey());
+		character1.setProperty("groupStatus", GroupStatus.Admin.name());
+		String partyCode = "partyCode";
+		character1.setProperty("partyCode", partyCode);
+		testObj.getDB().put(character1);
+		CachedEntity character2 = new CachedEntity("Character");
+		character2.setProperty("locationKey", currentLocationKey);
+		character2.setProperty("ownerKey", user.getKey());
+		character2.setProperty("partyCode", partyCode);
+		character1.setProperty("partyLeader", "TRUE");
+		character2.setProperty("groupKey", group2.getKey());
+		character2.setProperty("groupStatus", GroupStatus.Member.name());
+		testObj.getDB().put(character2);
+		CachedEntity destinationEntity = new CachedEntity("Location");
+		destinationEntity.setProperty("ownerKey", group1.getKey());
+		testObj.getDB().put(destinationEntity);
+		CachedEntity path = new CachedEntity("Path");
+		path.setProperty("location1Key", currentLocationKey);
+		path.setProperty("location2Key", destinationEntity.getKey());
+		path.setProperty("ownerKey", group1.getKey());
+		testObj.getDB().put(path);
+		
+		testObj.doCharacterTakePath(testObj.getDB(), character2, path , false);
+	}
+}

--- a/Initium-Odp/test/helper/utilities/HttpServletRequestImpl.java
+++ b/Initium-Odp/test/helper/utilities/HttpServletRequestImpl.java
@@ -1,0 +1,344 @@
+package helper.utilities;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.security.Principal;
+import java.util.Enumeration;
+import java.util.Locale;
+import java.util.Map;
+
+import javax.servlet.RequestDispatcher;
+import javax.servlet.ServletInputStream;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
+
+public class HttpServletRequestImpl implements HttpServletRequest {
+
+	@Override
+	public Object getAttribute(String arg0) {
+		return null;
+	}
+
+	@SuppressWarnings("rawtypes")
+	@Override
+	public Enumeration getAttributeNames() {
+		return null;
+	}
+
+	@Override
+	public String getCharacterEncoding() {
+		return null;
+	}
+
+	@Override
+	public int getContentLength() {
+		return 0;
+	}
+
+	@Override
+	public String getContentType() {
+		return null;
+	}
+
+	@Override
+	public ServletInputStream getInputStream() throws IOException {
+		
+		return null;
+	}
+
+	@Override
+	public String getLocalAddr() {
+		
+		return null;
+	}
+
+	@Override
+	public String getLocalName() {
+		
+		return null;
+	}
+
+	@Override
+	public int getLocalPort() {
+		
+		return 0;
+	}
+
+	@Override
+	public Locale getLocale() {
+		
+		return null;
+	}
+
+	@SuppressWarnings("rawtypes")
+	@Override
+	public Enumeration getLocales() {
+		
+		return null;
+	}
+
+	@Override
+	public String getParameter(String arg0) {
+		
+		return null;
+	}
+
+	@SuppressWarnings("rawtypes")
+	@Override
+	public Map getParameterMap() {
+		
+		return null;
+	}
+
+	@SuppressWarnings("rawtypes")
+	@Override
+	public Enumeration getParameterNames() {
+		
+		return null;
+	}
+
+	@Override
+	public String[] getParameterValues(String arg0) {
+		
+		return null;
+	}
+
+	@Override
+	public String getProtocol() {
+		
+		return null;
+	}
+
+	@Override
+	public BufferedReader getReader() throws IOException {
+		
+		return null;
+	}
+
+	@Override
+	public String getRealPath(String arg0) {
+		
+		return null;
+	}
+
+	@Override
+	public String getRemoteAddr() {
+		
+		return null;
+	}
+
+	@Override
+	public String getRemoteHost() {
+		
+		return null;
+	}
+
+	@Override
+	public int getRemotePort() {
+		
+		return 0;
+	}
+
+	@Override
+	public RequestDispatcher getRequestDispatcher(String arg0) {
+		
+		return null;
+	}
+
+	@Override
+	public String getScheme() {
+		
+		return null;
+	}
+
+	@Override
+	public String getServerName() {
+		
+		return null;
+	}
+
+	@Override
+	public int getServerPort() {
+		
+		return 0;
+	}
+
+	@Override
+	public boolean isSecure() {
+		
+		return false;
+	}
+
+	@Override
+	public void removeAttribute(String arg0) {
+		
+		
+	}
+
+	@Override
+	public void setAttribute(String arg0, Object arg1) {
+		
+		
+	}
+
+	@Override
+	public void setCharacterEncoding(String arg0) throws UnsupportedEncodingException {
+		
+		
+	}
+
+	@Override
+	public String getAuthType() {
+		
+		return null;
+	}
+
+	@Override
+	public String getContextPath() {
+		
+		return null;
+	}
+
+	@Override
+	public Cookie[] getCookies() {
+		
+		return null;
+	}
+
+	@Override
+	public long getDateHeader(String arg0) {
+		
+		return 0;
+	}
+
+	@Override
+	public String getHeader(String arg0) {
+		
+		return null;
+	}
+
+	@SuppressWarnings("rawtypes")
+	@Override
+	public Enumeration getHeaderNames() {
+		
+		return null;
+	}
+
+	@SuppressWarnings("rawtypes")
+	@Override
+	public Enumeration getHeaders(String arg0) {
+		
+		return null;
+	}
+
+	@Override
+	public int getIntHeader(String arg0) {
+		
+		return 0;
+	}
+
+	@Override
+	public String getMethod() {
+		
+		return null;
+	}
+
+	@Override
+	public String getPathInfo() {
+		
+		return null;
+	}
+
+	@Override
+	public String getPathTranslated() {
+		
+		return null;
+	}
+
+	@Override
+	public String getQueryString() {
+		
+		return null;
+	}
+
+	@Override
+	public String getRemoteUser() {
+		
+		return null;
+	}
+
+	@Override
+	public String getRequestURI() {
+		
+		return null;
+	}
+
+	@Override
+	public StringBuffer getRequestURL() {
+		
+		return null;
+	}
+
+	@Override
+	public String getRequestedSessionId() {
+		
+		return null;
+	}
+
+	@Override
+	public String getServletPath() {
+		
+		return null;
+	}
+
+	@Override
+	public HttpSession getSession() {
+		
+		return null;
+	}
+
+	@Override
+	public HttpSession getSession(boolean arg0) {
+		
+		return null;
+	}
+
+	@Override
+	public Principal getUserPrincipal() {
+		
+		return null;
+	}
+
+	@Override
+	public boolean isRequestedSessionIdFromCookie() {
+		
+		return false;
+	}
+
+	@Override
+	public boolean isRequestedSessionIdFromURL() {
+		
+		return false;
+	}
+
+	@Override
+	public boolean isRequestedSessionIdFromUrl() {
+		
+		return false;
+	}
+
+	@Override
+	public boolean isRequestedSessionIdValid() {
+		
+		return false;
+	}
+
+	@Override
+	public boolean isUserInRole(String arg0) {
+		
+		return false;
+	}
+
+}

--- a/Initium-Odp/war/WEB-INF/odppages/view_profile.jsp
+++ b/Initium-Odp/war/WEB-INF/odppages/view_profile.jsp
@@ -165,6 +165,13 @@
 <hr>
 
 <h2>Your Character</h2>
+
+<c:if test="${charName=='Unnamed'}">
+	<p>
+		<br> <br> <a class='big-link' href='#' onclick='renameCharacter("${charName}")' id='btnRenameCharacter'>Rename your character</a>
+	</p>
+</c:if>
+
 <p>
 	<br> <br> <a class='big-link' href='#' onclick='deleteAndRecreateCharacter("${charName}")' id='btnNewCharacter'>Delete your character and recreate</a>
 </p>

--- a/Initium-Odp/war/WEB-INF/odppages/view_profile.jsp
+++ b/Initium-Odp/war/WEB-INF/odppages/view_profile.jsp
@@ -168,7 +168,7 @@
 
 <c:if test="${charName=='Unnamed'}">
 	<p>
-		<br> <br> <a class='big-link' href='#' onclick='renameCharacter("${charName}")' id='btnRenameCharacter'>Rename your character</a>
+		<br> <br> <a class='big-link' href='#' onclick='renameCharacter(event, "${charName}")' id='btnRenameCharacter'>Rename your character</a>
 	</p>
 </c:if>
 

--- a/Initium-Odp/war/odp/MiniUP.css
+++ b/Initium-Odp/war/odp/MiniUP.css
@@ -2613,7 +2613,7 @@ body
 
 .banner1
 {
-	background-image:url("https://initium-resources.appspot.com/images/banner---animated-stream-waterfall1.gif");
+	background-image:url("https://initium-resources.appspot.com/images/hdbanners/banner---rocky-moutains-forest1.jpg");
 	background-position:top center;
 	background-repeat:no-repeat;
 	background-size:contain;

--- a/Initium-Odp/war/odp/chatHelp.html
+++ b/Initium-Odp/war/odp/chatHelp.html
@@ -12,7 +12,7 @@
 					href="https://docs.google.com/drawings/d/1ZGBwTTrY5ATlJOWrPnwH2qWkee7kgdRTnTDPVHYZ3Ak/edit?usp=sharing">you
 						can also find here.</a>
 				</li>
-				<li>/customize - This allows you to share a link to the iten
+				<li>/customize - This allows you to share a link to the item
 					customization page. <a onclick="customizeItemOrderPage()">You
 						can also find it here</a>
 				</li>
@@ -30,7 +30,7 @@
 				</li>
 				<li>/mechanics - Easily share the link to the official
 					'mechanics' page on this site. It goes into more detail about how
-					the game works. <a href="mechanics.jsp">Open mechanics page.</a>
+					the game works. <a href="/odp/mechanics.jsp">Open mechanics page.</a>
 				</li>
 				<li>/premium - Easily share a link to where people can learn
 					about premium accounts.</li>

--- a/Initium-Odp/war/odp/common-head.jsp
+++ b/Initium-Odp/war/odp/common-head.jsp
@@ -38,7 +38,7 @@
 <script type="text/javascript" src="/javascript/jquery.cluetip.all.min.js"></script>
 <link type="text/css" rel="stylesheet" href="/javascript/jquery.cluetip.css"/>
 
-<link type="text/css" rel="stylesheet" href="/odp/MiniUP.css?v=55">
+<link type="text/css" rel="stylesheet" href="/odp/MiniUP.css?v=56">
 
 <link type="text/css" rel="stylesheet" href="/javascript/rangeslider/rangeslider.css"/>
 <script src="javascript/rangeslider/rangeslider.min.js"></script>

--- a/Initium-Odp/war/odp/javascript/script.js
+++ b/Initium-Odp/war/odp/javascript/script.js
@@ -1553,6 +1553,13 @@ function viewMap()
 	openMap();
 }
 
+function renameCharacter(currentCharName)
+{
+	promptPopup("Rename Character", "Ok, what will you call your character?", currentCharName, function(name){
+		doCommand(eventObject, "RenameUnnamedPlayer", {"newName":name});
+	});
+}
+
 function deleteAndRecreateCharacter(currentCharName)
 {
 	confirmPopup("New Character", "Are you suuuure you want to delete your character and start over? It's permanent!", function(){

--- a/Initium-Odp/war/odp/javascript/script.js
+++ b/Initium-Odp/war/odp/javascript/script.js
@@ -1553,7 +1553,7 @@ function viewMap()
 	openMap();
 }
 
-function renameCharacter(currentCharName)
+function renameCharacter(eventObject, currentCharName)
 {
 	promptPopup("Rename Character", "Ok, what will you call your character?", currentCharName, function(name){
 		doCommand(eventObject, "RenameUnnamedPlayer", {"newName":name});


### PR DESCRIPTION
Allow players to enter user owned locations in a party of the user's own characters. Refactoring around player entry code to locations; both in and out of party.
Added LOTS of testing code around refactorings. Testing code can be refactored in to shared modules, eventually.

Added a service call to check if a character can travel a path (Requested by initiumdev). 