### PR TITLE
A slight change in the css positioning of the low-durability and very-low durability warning signs.

### DIFF
--- a/Initium-Odp/war/odp/MiniUP.css
+++ b/Initium-Odp/war/odp/MiniUP.css
@@ -2040,13 +2040,13 @@ hr.items-separator {
 .low-durability:before {
 	content: url('https://initium-resources.appspot.com/images/ui/equipment-warning1.png');
 	position: relative;
-	right: 5%;
+	right: 0.5%;
 	top: -5px;
 }
 .very-low-durability:before {
 	content: url('https://initium-resources.appspot.com/images/ui/equipment-warning2.png');
 	position: relative;
-	right: 5%;
+	right: 0.5%;
 	top: -5px;
 }
 .big-link


### PR DESCRIPTION
The warning indicator is placed just between the item icon and the item name. 