### PR TITLE
Removing 100% width/height from groundLayer CSS

### DIFF
--- a/Initium-Odp/war/odp/MiniUP.css
+++ b/Initium-Odp/war/odp/MiniUP.css
@@ -3192,7 +3192,5 @@ body
 }
 
 .groundLayerContainer {
-	height: 100%;
-	width: 100%;
 	/*border: 1px solid black;*/
 }

--- a/Initium-Odp/war/odp/MiniUP.css
+++ b/Initium-Odp/war/odp/MiniUP.css
@@ -3185,8 +3185,6 @@ body
 }
 
 .vp {
-	height: 100%;
-	width: 100%;
 	top: 0; right: 0; bottom: 0; left: 0;
 	/*border: 1px solid black;*/
 }


### PR DESCRIPTION
I'm not sure this will fix it, but hopefully?