### PR TITLE
Another wording fix

### DIFF
--- a/Initium-Odp/src/com/universeprojects/miniup/server/ODPDBAccess.java
+++ b/Initium-Odp/src/com/universeprojects/miniup/server/ODPDBAccess.java
@@ -3930,8 +3930,13 @@ public class ODPDBAccess
 		            String armorNames = "";
 		            for(int i = 0; i<blockingArmor.size();i++)
 		            {
-		                if (i>0)
-		                    armorNames+=", ";
+		                if (i>0) 
+				{
+				    if (blockingArmor.size() == 2)
+					armorNames += " and ";
+				    else 
+					armorNames+=", ";
+				}
 		                if (i==blockingArmor.size()-1 && i>0)
 		                    armorNames+="and ";
 		                armorNames+=(String)blockingArmor.get(i).getProperty("name");


### PR DESCRIPTION
Pasting from the relevant commit:  

Before this commit, if an attack was blocked by 2 pieces of armor, it would print as    
`The attack was {partially/completely} blocked due to the Armor1, and Armor2` - that is grammatically wrong and always kinda irked me a bit whenever I saw it.     

This commit basically removes the comma if there are only two pieces of armor doing protection.  

Also why don't you use StringBuilder or StringBuffer for this?  

Also your bracketing style kinda confuses me a bit, so if mine are not like how you'd normally do it, fix it pls.