### PR TITLE
Remove party from combat after character is killed

### DIFF
--- a/Initium-Odp/src/com/universeprojects/miniup/server/ODPDBAccess.java
+++ b/Initium-Odp/src/com/universeprojects/miniup/server/ODPDBAccess.java
@@ -4294,6 +4294,14 @@ public class ODPDBAccess
 					attackingCharacter.setProperty("combatType", null);
 					attackingCharacter.setProperty("locationEntryDatetime", new Date());
 	
+					// Make the attacking character party no longer in combat mode
+					List<CachedEntity> party = getParty(ds, attackingCharacterFinal);
+					if (party != null) {
+						setPartiedField(party, attackingCharacterFinal, "mode", CHARACTER_MODE_NORMAL);
+						setPartiedField(party, attackingCharacterFinal, "combatant", null);
+						setPartiedField(party, attackingCharacterFinal, "combatType", null);
+						setPartiedField(party, attackingCharacterFinal, "locationEntryDatetime", new Date());
+					}
 					
 					////////////////////////
 					// Now, depending on if the killed character is an NPC or not, and if the killer is an NPC or not, do some stuff...

--- a/Initium-Odp/src/com/universeprojects/miniup/server/ODPDBAccess.java
+++ b/Initium-Odp/src/com/universeprojects/miniup/server/ODPDBAccess.java
@@ -4297,10 +4297,10 @@ public class ODPDBAccess
 					// Make the attacking character party no longer in combat mode
 					List<CachedEntity> party = getParty(ds, attackingCharacterFinal);
 					if (party != null) {
-						setPartiedField(party, attackingCharacterFinal, "mode", CHARACTER_MODE_NORMAL);
-						setPartiedField(party, attackingCharacterFinal, "combatant", null);
-						setPartiedField(party, attackingCharacterFinal, "combatType", null);
-						setPartiedField(party, attackingCharacterFinal, "locationEntryDatetime", new Date());
+						setPartiedField(party, attackingCharacter, "mode", ODPDBAccess.CHARACTER_MODE_NORMAL);
+						setPartiedField(party, attackingCharacter, "combatant", null);
+						setPartiedField(party, attackingCharacter, "combatType", null);
+						setPartiedField(party, attackingCharacter, "locationEntryDatetime", new Date());
 					}
 					
 					////////////////////////

--- a/Initium-Odp/src/com/universeprojects/miniup/server/ODPDBAccess.java
+++ b/Initium-Odp/src/com/universeprojects/miniup/server/ODPDBAccess.java
@@ -4425,6 +4425,9 @@ public class ODPDBAccess
 					db.put(characterToDie);
 					db.put(dyingCharacterLocation);
 					db.put(attackingCharacter);
+					if (party != null) {
+						putPartyMembersToDB_SkipSelf(db, party, attackingCharacter);
+					}
 					
 					Map<String, Object> result = new HashMap<String, Object>();
 					


### PR DESCRIPTION
In addition to removing attacking character from combat,
also remove party members if needed.