### PR TITLE
First hand at instance combat fix

### DIFF
--- a/Initium-Odp/src/com/universeprojects/miniup/server/ODPDBAccess.java
+++ b/Initium-Odp/src/com/universeprojects/miniup/server/ODPDBAccess.java
@@ -43,6 +43,7 @@ import com.universeprojects.cacheddatastore.QueryHelper;
 import com.universeprojects.miniup.CommonChecks;
 import com.universeprojects.miniup.server.commands.framework.UserErrorMessage;
 import com.universeprojects.miniup.server.longoperations.AbortedActionException;
+import com.universeprojects.miniup.server.services.BlockadeService;
 import com.universeprojects.miniup.server.services.ContainerService;
 import com.universeprojects.miniup.server.services.MovementService;
 import com.universeprojects.miniup.server.services.ODPInventionService;
@@ -5139,13 +5140,16 @@ public class ODPDBAccess
 	
 	public CachedEntity doCharacterTakePath(CachedDatastoreService db, CachedEntity character, CachedEntity path, boolean allowAttack) throws UserErrorMessage
 	{
+		return doCharacterTakePath(db, character, path, allowAttack, false);
+	}
+	
+	public CachedEntity doCharacterTakePath(CachedDatastoreService db, CachedEntity character, CachedEntity path, boolean allowAttack, boolean isExplore) throws UserErrorMessage
+	{
 		if (db==null)
 			db = getDB();
 
 		if (CHARACTER_MODE_COMBAT.equals(character.getProperty("mode")))
 			throw new UserErrorMessage("You cannot move while you're in combat.");
-		
-		
 		
 		CachedEntity destination = null;
 		Key destinationKey = null;
@@ -5175,19 +5179,18 @@ public class ODPDBAccess
 
 		String partyCode = (String) character.getProperty("partyCode");
 		boolean isInParty = partyCode != null && !"".equals(partyCode);
-
+		List<CachedEntity> party = getParty(db, character);
+		// We use the party collection for non-partied character as well.
+		if (party == null) party = Collections.singletonList(character);
 		MovementService movementService = new MovementService(this);
 
 		Key ownerKey = (Key) destination.getProperty("ownerKey");
 		if (ownerKey != null) {
 			// Check to see if all members of the party have access to enter owned housing.
-			List<CachedEntity> partyMembers = getParty(db, character);
-			if (partyMembers == null) partyMembers = Collections.singletonList(character); // You are the only party member
-
 			if("Group".equals(ownerKey.getKind())){
 				Set<String> groupKeySet = new HashSet<String>(); // Sets guarantee one and only one entry per unique value
 				List<String> isActiveInGroupStatusList = Arrays.asList(GroupStatus.Admin.name(), GroupStatus.Member.name()); // Wish we had streaming to build this appropriately
-				for(CachedEntity partyMember: partyMembers) {
+				for(CachedEntity partyMember: party) {
 					//Removes those who have just applied or have been kicked
 					boolean belongstoGroup = isActiveInGroupStatusList.contains(partyMember.getProperty("groupStatus"));
 					Key groupKey = (Key) partyMember.getProperty("groupKey"); // This should always be here if they belong to a group
@@ -5196,14 +5199,14 @@ public class ODPDBAccess
 				}
 
 				if(!groupKeySet.contains(ownerKey.toString()) || groupKeySet.size() != 1) { // Check for non-matching keys
-					throw new UserErrorMessage(String.format("You cannot enter a group owned house unless %s.", partyMembers.size() > 1 ? "all members of your party are members of the group" : "you are a member of the group"));
+					throw new UserErrorMessage(String.format("You cannot enter a group owned house unless %s.", party.size() > 1 ? "all members of your party are members of the group" : "you are a member of the group"));
 				}
 			} else if("User".equals(ownerKey.getKind())) {
 				Key pathOwner = (Key) path.getProperty("ownerKey");
-				for (CachedEntity partyMember : partyMembers) {
+				for (CachedEntity partyMember : party) {
 					boolean isPathOwner = GameUtils.equals(pathOwner, partyMember.getProperty("userKey"));
 					if (!isPathOwner && !movementService.isPathDiscovered(partyMember.getKey(), path.getKey())) {
-						throw new UserErrorMessage(String.format("You cannot enter a player owned house unless %s.", partyMembers.size() > 1 ? "every character already has been given access" : "you already have been given access"));
+						throw new UserErrorMessage(String.format("You cannot enter a player owned house unless %s.", party.size() > 1 ? "every character already has been given access" : "you already have been given access"));
 					}
 				}
 			} else {
@@ -5214,122 +5217,127 @@ public class ODPDBAccess
 		// Check if this property is locked and if so, if we have the key to enter it...
 		movementService.checkForLocks(character, path, destinationKey);
 
-		// Check if we're being blocked by the blockade
-		CachedEntity blockadeStructure = getBlockadeFor(character, destination);
-		
-		if (isInParty && blockadeStructure!=null)
-			throw new UserErrorMessage("You are approaching a defensive structure but you cannot attack as a party. Disband your party before attacking the defensive structure.");
-		
-		if (isInParty && "Instance".equals(destination.getProperty("combatType")))
-			throw new UserErrorMessage("You are approaching an instance but cannot attack as a party. Disband your party before attacking the instance (you can still do it together, just not using party mechanics).");
-		
-		if (allowAttack==false && blockadeStructure!=null)
-			throw new UserErrorMessage("You are approaching a defensive structure which will cause you to enter into combat with whoever is defending the structure. Are you sure you want to approach?<br><br><a href='ServletCharacterControl?type=goto&pathId="+path.getKey().getId()+"&attack=true'>Click here to attack!</a>", false);
-
-
-		
-		
-		
-		List<CachedEntity> party = null;
-		EngageBlockadeOpponentResult opponentResult = null; 
-		
-		// Set the character's new location AND all party members if applicable...
-		if (isInParty==false)
-		{
-			// Here is where we'll check if we're entering combat with a defending player...
-			System.out.println("");
-			if (blockadeStructure!=null)
-				opponentResult = engageBlockadeOpponent(db, character.getKey(), currentLocationKey, destination, (Key)blockadeStructure.getProperty("locationKey"), blockadeStructure);
-			
-			if (opponentResult==null || opponentResult.freeToPass)
-			{
-				// There are no opponents at all so allow the player to advance
-				character.setProperty("locationKey", destination.getKey());
-			}
-			else if (opponentResult.defender!=null)
-			{
-				// We're engaging the enemy! We need to get out of here
-				return null;
-			}
-			else if (opponentResult.defender==null && opponentResult.freeToPass==false && opponentResult.onlyNPCDefenders==true)
-			{
-				// There are no opponents available AND all opponents are NPC opponents, so we will let the player pass
-				character.setProperty("locationKey", destination.getKey());
-			}
-			else if (opponentResult.defender==null && opponentResult.freeToPass==false && opponentResult.onlyNPCDefenders==false)
-			{
-				// This situation occurs when all the defenders are busy, the player has to wait for combat
-				throw new UserErrorMessage("There is active combat going on at this site but you have no room to engage and cannot pass. Try again later.", false);
-			}
-			else
-				throw new RuntimeException("Unhandled situation exception.");
-			
-			
-		}
-		else
-		{
-			party = getParty(db, character);
-			if ("TRUE".equals(character.getProperty("partyLeader"))==false)
-				throw new UserErrorMessage("You cannot move the party because you're not the party leader.");
-			
-			setPartiedField(party, character, "locationKey", destination.getKey());
-			
-			// Discover the path the party is taking if we haven't already discovered it..
-			if (party!=null)
-				for(CachedEntity member:party)
-					if (member.getKey().getId()!=character.getKey().getId())
-					{
-						doCharacterDiscoverEntity(db, member, path);
-						
-						sendNotification(db, member.getKey(), NotificationType.fullpageRefresh);
-					}
-			
-//			character.setProperty("locationKey", destination.getKey());
-//			party = getParty(db, character);
-//			if (party!=null)
-//				for(CachedEntity member:party)
-//					if (member.getKey().getId()!=character.getKey().getId())
-//					{
-//						member.setProperty("locationKey", destination.getKey());
-//						doCharacterDiscoverEntity(db, member, path);
-//						
-//						db.put(member);
-//					}
-		}
-
 		// If this destination is a town, then we will want to change the homeTownKey now
 		if ("Town".equals(destination.getProperty("type")))
 			character.setProperty("homeTownKey", destinationKey);
-		
-		
 
-		// Now determine if the path contains an NPC that the character would immediately enter battle with...
-		List<CachedEntity> npcsInTheArea = getFilteredList("Character", 300, "locationKey", FilterOperator.EQUAL, destinationKey);
-		npcsInTheArea = new ArrayList<CachedEntity>(npcsInTheArea);
+		// We've already checked this when performing the TakePath
+		// long operation. Only should check this when exploring
+		if(isExplore)
+		{
+			BlockadeService bs = new BlockadeService(this);
+			// Check if we're being blocked by the blockade
+			CachedEntity blockadeStructure = bs.getBlockadeFor(character, destination);
+			
+			if (isInParty && blockadeStructure!=null)
+				throw new UserErrorMessage("You are approaching a defensive structure but you cannot attack as a party. Disband your party before attacking the defensive structure.");
+			
+			if (isInParty && "Instance".equals(destination.getProperty("combatType")))
+				throw new UserErrorMessage("You are approaching an instance but cannot attack as a party. Disband your party before attacking the instance (you can still do it together, just not using party mechanics).");
+			
+			if (allowAttack==false && blockadeStructure!=null)
+				throw new UserErrorMessage("You are approaching a defensive structure which will cause you to enter into combat with whoever is defending the structure. Are you sure you want to approach?<br><br><a onclick='closeAllPopups();doGoto(event,"+path.getKey().getId()+",true)'>Click here to attack!</a>", false);
 
-		shuffleCharactersByAttackOrder(npcsInTheArea);
-		
-		for(CachedEntity possibleNPC:npcsInTheArea)
-			if ("NPC".equals(possibleNPC.getProperty("type")) && (Double)possibleNPC.getProperty("hitpoints")>0d)
+			EngageBlockadeOpponentResult opponentResult = null; 
+			
+			// Set the character's new location AND all party members if applicable...
+			if (isInParty==false)
 			{
-				resetInstanceRespawnTimer(destination);
-				setPartiedField(party, character, "mode", CHARACTER_MODE_COMBAT);
-				setPartiedField(party, character, "combatant", possibleNPC.getKey());
+				// Here is where we'll check if we're entering combat with a defending player...
+				System.out.println("");
+				if (blockadeStructure!=null)
+					opponentResult = bs.engageBlockadeOpponent(character.getKey(), currentLocationKey, destination, (Key)blockadeStructure.getProperty("locationKey"), blockadeStructure);
 				
-				// For forced 1v1 combat, we also need to set the combatant on the monster
-				if (CommonChecks.checkLocationIsInstance(destination))
+				if (opponentResult==null || opponentResult.freeToPass)
 				{
+					// There are no opponents at all so allow the player to advance
+					character.setProperty("locationKey", destination.getKey());
+				}
+				else if (opponentResult.defender!=null)
+				{
+					// We're engaging the enemy! We need to get out of here
+					return null;
+				}
+				else if (opponentResult.defender==null && opponentResult.freeToPass==false && opponentResult.onlyNPCDefenders==true)
+				{
+					// There are no opponents available AND all opponents are NPC opponents, so we will let the player pass
+					character.setProperty("locationKey", destination.getKey());
+				}
+				else if (opponentResult.defender==null && opponentResult.freeToPass==false && opponentResult.onlyNPCDefenders==false)
+				{
+					// This situation occurs when all the defenders are busy, the player has to wait for combat
+					throw new UserErrorMessage("There is active combat going on at this site but you have no room to engage and cannot pass. Try again later.", false);
+				}
+				else
+					throw new RuntimeException("Unhandled situation exception.");
+			}
+			else
+			{
+				if ("TRUE".equals(character.getProperty("partyLeader"))==false)
+					throw new UserErrorMessage("You cannot move the party because you're not the party leader.");
+				
+				setPartiedField(party, character, "locationKey", destination.getKey());
+				
+				// Discover the path the party is taking if we haven't already discovered it..
+				if (party!=null)
+					for(CachedEntity member:party)
+						if (member.getKey().getId()!=character.getKey().getId())
+						{
+							doCharacterDiscoverEntity(db, member, path);
+							
+							sendNotification(db, member.getKey(), NotificationType.fullpageRefresh);
+						}
+			}
+
+			// Now determine if the path contains an NPC that the character would immediately enter battle with...
+			QueryHelper qh = new QueryHelper(ds);
+			List<CachedEntity> npcsInTheArea = qh.getFilteredList("Character", 500, null, "locationKey", FilterOperator.EQUAL, destinationKey, "type", FilterOperator.EQUAL, "NPC");
+			npcsInTheArea = new ArrayList<CachedEntity>(npcsInTheArea);
+
+			shuffleCharactersByAttackOrder(npcsInTheArea);
+			boolean isCombatSite = CommonChecks.checkLocationIsCombatSite(destination);
+			int partyIdx = 0;
+			for(CachedEntity possibleNPC:npcsInTheArea)
+				if ((isCombatSite || possibleNPC.getProperty("mode") == null || CHARACTER_MODE_NORMAL.equals(possibleNPC.getProperty("mode"))) && 
+						(Double)possibleNPC.getProperty("hitpoints")>0d)
+				{
+					resetInstanceRespawnTimer(destination);
+					CachedEntity curMember = party.get(partyIdx++);
+					
+					curMember.setProperty("mode", CHARACTER_MODE_COMBAT);
+					curMember.setProperty("combatant", possibleNPC.getKey());
 					possibleNPC.setProperty("mode", CHARACTER_MODE_COMBAT);
-					possibleNPC.setProperty("combatant", character.getKey());
+					// For forced 1v1 combat, we also need to set the combatant on the monster
+					if (CommonChecks.checkLocationIsInstance(destination))
+					{
+						possibleNPC.setProperty("combatant", character.getKey());
+					}
 					ds.put(possibleNPC);
+					
+					if(partyIdx >= party.size())
+						break;		
+				}
+			
+			// Here we're going to take a list we got from the opponentResult stuff and reuse it for performance reasons...
+			// We're going to determine if we should refresh the leader on the defence structure we just arrived at or left from
+			if (opponentResult!=null && opponentResult.charactersInBlockade!=null)
+			{
+				for(int i = 0; i<opponentResult.charactersInBlockade.size(); i++)
+				{
+					if (opponentResult.charactersInBlockade.get(i).getKey().getId() == character.getKey().getId())
+					{
+						opponentResult.charactersInBlockade.set(i, character);
+						break;
+					}
 				}
 				
-				break;
-//				// If we've been interrupted, we'll just get out and not actually travel to the location, but ONLY
-//				// if we're not entering a CombatSite!
-//				if ("CombatSite".equals(destination.getProperty("type"))==false)
-//					return;		
+				// Check if we are entering a defence structure location
+				if (blockadeStructure != null)
+				{
+					refreshDefenceStructureLeader(db, blockadeStructure, opponentResult.charactersInBlockade);
+				}
 			}
+		}
 		
 		// Now check if we have a discovery for this path we just took...
 		CachedEntity discovery = getDiscoveryByEntity(character.getKey(), path.getKey()); 
@@ -5369,34 +5377,11 @@ public class ODPDBAccess
 		
 		putPartyMembersToDB_SkipSelf(db, party, character);
 		
-		
-		// Here we're going to take a list we got from the opponentResult stuff and reuse it for performance reasons...
-		// We're going to determine if we should refresh the leader on the defence structure we just arrived at or left from
-		if (opponentResult!=null && opponentResult.charactersInBlockade!=null)
-		{
-			for(int i = 0; i<opponentResult.charactersInBlockade.size(); i++)
-			{
-				if (opponentResult.charactersInBlockade.get(i).getKey().getId() == character.getKey().getId())
-				{
-					opponentResult.charactersInBlockade.set(i, character);
-					break;
-				}
-			}
-			
-			// Check if we are entering a defence structure location
-			if (blockadeStructure != null)
-			{
-				refreshDefenceStructureLeader(db, blockadeStructure, opponentResult.charactersInBlockade);
-			}
-			
-		}
-		
 		if (destination.isUnsaved())
 			ds.put(destination);
 		
 		return destination;
 	}
-	
 	
 	public class EngageBlockadeOpponentResult
 	{

--- a/Initium-Odp/src/com/universeprojects/miniup/server/ODPDBAccess.java
+++ b/Initium-Odp/src/com/universeprojects/miniup/server/ODPDBAccess.java
@@ -5395,13 +5395,13 @@ public class ODPDBAccess
 			ds.put(destination);
 		
 		// Send main-page update for all party members but the leader.
-		List<Key> keys = new ArrayList<Key>();
+		List<Key> partyKeys = new ArrayList<Key>();
 		for(CachedEntity chars:party)
 			if(GameUtils.equals(chars.getKey(), character.getKey())==false)
-				keys.add(chars.getKey());
+				partyKeys.add(chars.getKey());
 		
-		if(keys.isEmpty()==false)
-			sendMainPageUpdateForCharacters(db, keys, "shortcut_fullPageUpdate");
+		if(partyKeys.isEmpty()==false)
+			sendMainPageUpdateForCharacters(db, partyKeys, "shortcut_fullPageUpdate");
 		
 		return destination;
 	}

--- a/Initium-Odp/src/com/universeprojects/miniup/server/commands/CommandCombatAttack.java
+++ b/Initium-Odp/src/com/universeprojects/miniup/server/commands/CommandCombatAttack.java
@@ -44,7 +44,7 @@ public class CommandCombatAttack extends Command
 		
 		if (GameUtils.isPlayerIncapacitated(character))
 		{
-			mpus.shortcut_fullPageUpdate(cs);
+			mpus.shortcut_fullPageUpdate();
 			setPopupMessage("You are incapacitated and cannot attack.");
 			return;
 		}
@@ -57,13 +57,13 @@ public class CommandCombatAttack extends Command
 		if (targetCharacter==null)
 		{
 			cs.leaveCombat(character, null);
-			mpus.shortcut_fullPageUpdate(cs);
+			mpus.shortcut_fullPageUpdate();
 			return;
 		}
 		if (cs.isInCombatWith(character, targetCharacter, location)==false && CommonChecks.checkLocationIsInstance(location))
 		{
 			cs.leaveCombat(character, null);
-			mpus.shortcut_fullPageUpdate(cs);			
+			mpus.shortcut_fullPageUpdate();			
 			throw new UserErrorMessage("You're not in combat with this opponent, someone else is. This can happen if someone else entered combat around the same time as you.");
 		}
 		
@@ -217,9 +217,8 @@ public class CommandCombatAttack extends Command
 		{
 			if (CommonChecks.checkLocationIsCombatSite(location)) location = ds.refetch(location);
 			// We're done with combat
-			cs = new CombatService(db);
 			mpus = new MainPageUpdateService(db, db.getCurrentUser(), db.getCurrentCharacter(), location, this);
-			mpus.shortcut_fullPageUpdate(cs);
+			mpus.shortcut_fullPageUpdate();
 			return;
 		}
 		else

--- a/Initium-Odp/src/com/universeprojects/miniup/server/commands/CommandCombatEscape.java
+++ b/Initium-Odp/src/com/universeprojects/miniup/server/commands/CommandCombatEscape.java
@@ -37,14 +37,14 @@ public class CommandCombatEscape extends Command {
 		if (targetCharacter==null)
 		{
 			cs.leaveCombat(character, null);
-			mpus.shortcut_fullPageUpdate(cs);
+			mpus.shortcut_fullPageUpdate();
 			return;
 		}
 		
 		if (cs.isInCombatWith(character, targetCharacter, location)==false)
 		{
 			cs.leaveCombat(character, null);
-			mpus.shortcut_fullPageUpdate(cs);			
+			mpus.shortcut_fullPageUpdate();			
 			throw new UserErrorMessage("You're not in combat with this opponent, someone else is. This can happen if someone else entered combat around the same time as you.");
 		}
 		
@@ -90,7 +90,7 @@ public class CommandCombatEscape extends Command {
 		if (cs.isInCombat(character)==false || GameUtils.isPlayerIncapacitated(character))
 		{
 			// We're done with combat
-			mpus.shortcut_fullPageUpdate(cs);
+			mpus.shortcut_fullPageUpdate();
 			return;
 		}
 		else

--- a/Initium-Odp/src/com/universeprojects/miniup/server/commands/CommandScriptBase.java
+++ b/Initium-Odp/src/com/universeprojects/miniup/server/commands/CommandScriptBase.java
@@ -170,10 +170,9 @@ public abstract class CommandScriptBase extends Command {
 						CachedEntity location = db.getEntity((Key)character.getProperty("locationKey"));
 						CachedEntity user = db.getCurrentUser();
 						MainPageUpdateService mpus = new MainPageUpdateService(db, user, character, location, this);
-						CombatService cs = new CombatService(db);
 						if(event.getJavascriptResponse()==JavascriptResponse.FullPageRefresh)
 						{
-							mpus.shortcut_fullPageUpdate(cs);
+							mpus.shortcut_fullPageUpdate();
 						}
 						else if(event.reloadWidgets)
 						{

--- a/Initium-Odp/src/com/universeprojects/miniup/server/commands/CommandSwitchCharacter.java
+++ b/Initium-Odp/src/com/universeprojects/miniup/server/commands/CommandSwitchCharacter.java
@@ -89,9 +89,8 @@ public class CommandSwitchCharacter extends Command {
 		addJavascriptToResponse(js.toString());
 		
 		// Consolidating this to quick refresh the page
-		CombatService cs = new CombatService(db);
 		CachedEntity location = ds.getIfExists((Key) targetCharacter.getProperty("locationKey"));
 		MainPageUpdateService mpus = new MainPageUpdateService(db, db.getCurrentUser(), targetCharacter, location, this);
-		mpus.shortcut_fullPageUpdate(cs);
+		mpus.shortcut_fullPageUpdate();
 	}
 }

--- a/Initium-Odp/src/com/universeprojects/miniup/server/exceptions/UserErrorMessageRuntimeException.java
+++ b/Initium-Odp/src/com/universeprojects/miniup/server/exceptions/UserErrorMessageRuntimeException.java
@@ -1,0 +1,11 @@
+package com.universeprojects.miniup.server.exceptions; 
+
+public class UserErrorMessageRuntimeException extends RuntimeException 
+{     
+	public UserErrorMessageRuntimeException(String message) 
+	{         
+		super(message);
+		// TODO Auto-generated constructor stub     
+	} 
+	
+}

--- a/Initium-Odp/src/com/universeprojects/miniup/server/longoperations/LongOperation.java
+++ b/Initium-Odp/src/com/universeprojects/miniup/server/longoperations/LongOperation.java
@@ -327,7 +327,7 @@ public abstract class LongOperation extends OperationBase
 			cancelLongOperations(db, db.getCurrentCharacterKey());
 			
 			MainPageUpdateService mpus = new MainPageUpdateService(db, db.getCurrentUser(), db.getCurrentCharacter(), db.getEntity((Key)db.getCurrentCharacter().getProperty("locationKey")), this);
-			mpus.shortcut_fullPageUpdate(new CombatService(db));
+			mpus.shortcut_fullPageUpdate();
 
 			result.putAll(getStateData());
 			result.put("silentError", true);

--- a/Initium-Odp/src/com/universeprojects/miniup/server/longoperations/LongOperationExplore.java
+++ b/Initium-Odp/src/com/universeprojects/miniup/server/longoperations/LongOperationExplore.java
@@ -323,7 +323,7 @@ public class LongOperationExplore extends LongOperation {
 		db.newDiscovery(ds, db.getCurrentCharacter(), path);
 		
 		String mode = (String)db.getCurrentCharacter().getProperty("mode");
-		db.doCharacterTakePath(ds, db.getCurrentCharacter(), path);
+		db.doCharacterTakePath(ds, db.getCurrentCharacter(), path, false, true);
 	}
 	
 }

--- a/Initium-Odp/src/com/universeprojects/miniup/server/longoperations/LongOperationExplore.java
+++ b/Initium-Odp/src/com/universeprojects/miniup/server/longoperations/LongOperationExplore.java
@@ -70,9 +70,8 @@ public class LongOperationExplore extends LongOperation {
 		
 		if (GameUtils.equals(oldLocaiton, newLocation)==false || GameUtils.equals(oldCombatant, newCombatant)==false)
 		{
-			CombatService cs = new CombatService(db);
 			MainPageUpdateService update = new MainPageUpdateService(db, db.getCurrentUser(), db.getCurrentCharacter(), db.getEntity((Key)newLocation), this);
-			update.shortcut_fullPageUpdate(cs);
+			update.shortcut_fullPageUpdate();
 			
 		}
 		else

--- a/Initium-Odp/src/com/universeprojects/miniup/server/longoperations/LongOperationTakePath.java
+++ b/Initium-Odp/src/com/universeprojects/miniup/server/longoperations/LongOperationTakePath.java
@@ -233,9 +233,8 @@ public class LongOperationTakePath extends LongOperation {
 //			db.getDB().commitBulkWrite();
 		}
 
-		CombatService cs = new CombatService(db);
 		MainPageUpdateService update = new MainPageUpdateService(db, db.getCurrentUser(), db.getCurrentCharacter(), newLocation, this);
-		update.shortcut_fullPageUpdate(cs);
+		update.shortcut_fullPageUpdate();
 
 //		setFullRefresh(true);
 		

--- a/Initium-Odp/src/com/universeprojects/miniup/server/services/BlockadeService.java
+++ b/Initium-Odp/src/com/universeprojects/miniup/server/services/BlockadeService.java
@@ -1,0 +1,342 @@
+package com.universeprojects.miniup.server.services;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.ConcurrentModificationException;
+import java.util.List;
+
+import com.google.appengine.api.datastore.Key;
+import com.universeprojects.cacheddatastore.AbortTransactionException;
+import com.universeprojects.cacheddatastore.CachedDatastoreService;
+import com.universeprojects.cacheddatastore.CachedEntity;
+import com.universeprojects.miniup.server.InitiumTransaction;
+import com.universeprojects.miniup.server.NotificationType;
+import com.universeprojects.miniup.server.ODPDBAccess;
+import com.universeprojects.miniup.server.ODPDBAccess.EngageBlockadeOpponentResult;
+import com.universeprojects.miniup.server.commands.framework.UserErrorMessage;
+import com.universeprojects.miniup.server.exceptions.UserErrorMessageRuntimeException;
+
+public class BlockadeService extends Service 
+{
+
+	public BlockadeService(ODPDBAccess db) 
+	{
+		super(db);
+	}
+	
+	/**
+	* Returns the blockade that would block the given character if he were to travel to the given location.
+	*
+	* If no block would happen, this method returns null.
+	*
+	* @param character
+	* @param destinationLocation
+	* @return
+	*/
+	public CachedEntity getBlockadeFor(CachedEntity character, CachedEntity destinationLocation)
+	{         
+		if (character==null)
+			throw new IllegalArgumentException("Character cannot be null.");
+		if (destinationLocation==null)
+			throw new IllegalArgumentException("Location cannot be null.");
+		
+		if ("TRUE".equals(destinationLocation.getProperty("defenceStructuresAllowed"))==false)
+			return null;
+		
+		// Get all paths that lead from this location
+		List<CachedEntity> paths = db.getPathsByLocation(destinationLocation.getKey());
+		// Go through the paths looking for BlockadeSite types. We will need to look through those.
+		List<CachedEntity> blockadeLocations = new ArrayList<CachedEntity>();
+		// Also add our current location (right at the beginning)
+		if ("TRUE".equals(destinationLocation.getProperty("defenceStructuresAllowed")))
+		{
+			blockadeLocations.add(destinationLocation);
+		}
+		for(CachedEntity path:paths)
+			if ("BlockadeSite".equals(path.getProperty("type")))
+			{
+				if (((Key)path.getProperty("location1Key")).getId() == destinationLocation.getKey().getId())
+					blockadeLocations.add(db.getEntity((Key)path.getProperty("location2Key")));
+				else
+					blockadeLocations.add(db.getEntity((Key)path.getProperty("location1Key")));
+			}
+			
+		if (blockadeLocations.isEmpty())
+			return null;
+		
+		for(CachedEntity blockadeLocation:blockadeLocations)
+		{
+			CachedEntity blockadeStructure = db.getEntity((Key)blockadeLocation.getProperty("defenceStructure"));
+			if (blockadeStructure==null)
+				continue;
+			if (isBlockedByBlockadeRules(character, destinationLocation.getKey(), blockadeStructure))
+				return blockadeStructure;
+		}
+		
+		return null;
+	}
+	
+    /**
+     * THIS IS A TRANSACTION METHOD
+     * 
+     * 
+     * @param ds
+     * @param character
+     * @param startingLocation The location the character is currently in
+     * @param parentLocation The location that the defence structure's location links to. 
+     * @param blockadeLocation The location of the blockade itself.
+     * @param blockadeStructure
+     * @return
+     * @throws UserErrorMessage 
+     */
+    public EngageBlockadeOpponentResult engageBlockadeOpponent(final Key characterKey, final Key startingLocation, final CachedEntity parentLocation, final Key blockadeLocationKey, final CachedEntity blockadeStructure) throws UserErrorMessage
+    {
+    	CachedDatastoreService ds = db.getDB();
+        
+        if (characterKey==null)
+            throw new IllegalArgumentException("Character cannot be null.");
+        if (blockadeLocationKey==null)
+            throw new IllegalArgumentException("Blockade location cannot be null.");
+        if (blockadeStructure==null)
+            throw new IllegalArgumentException("Blockade structure cannot be null.");
+        final ODPDBAccess.EngageBlockadeOpponentResult finalResult = db.new EngageBlockadeOpponentResult();
+        
+        final List<CachedEntity> charactersInBlockade = query.getFilteredList("Character", "locationKey", blockadeLocationKey);
+        Collections.shuffle(charactersInBlockade);
+        try 
+        {
+            new InitiumTransaction<CachedEntity>(ds) 
+            {
+                
+                @Override
+                public CachedEntity doTransaction(CachedDatastoreService ds) 
+                {
+                    CachedEntity chosenOpponent = null;
+                    
+                    //Refetch the character entity because it will be changed in this transaction
+                    CachedEntity character = db.getEntity(characterKey);
+                    if (ODPDBAccess.CHARACTER_MODE_COMBAT.equals(character.getProperty("mode")))
+                        throw new UserErrorMessageRuntimeException("Character is already in combat. This action cannot be performed right now.");
+                    
+                    finalResult.charactersInBlockade = charactersInBlockade;
+                    
+                    if (startingLocation!=null && startingLocation.getId() == blockadeLocationKey.getId())
+                    {
+                        finalResult.freeToPass = true;
+                        return null;
+                    }
+                    
+                    // Here we'll include whether or not the character is free to pass the blockade
+                    finalResult.freeToPass = true;
+                    finalResult.hasDefenders = false;
+                    for(CachedEntity defender:charactersInBlockade)
+                        if (("Defending1".equals(defender.getProperty("status")) || "Defending2".equals(defender.getProperty("status")) || "Defending3".equals(defender.getProperty("status"))) && 
+                                (Double)defender.getProperty("hitpoints")>0)
+                        {
+                            finalResult.freeToPass = false;
+                            finalResult.hasDefenders = true;
+                            break;
+                        }
+                    finalResult.onlyNPCDefenders = true;
+                    for(CachedEntity defender:charactersInBlockade)
+                        if (("Defending1".equals(defender.getProperty("status")) || "Defending2".equals(defender.getProperty("status")) || "Defending3".equals(defender.getProperty("status"))) && 
+                                (Double)defender.getProperty("hitpoints")>0 && 
+                                "NPC".equals(defender.getProperty("type"))==false)
+                        {
+                            finalResult.onlyNPCDefenders = false;
+                            break;
+                        }
+                            
+                    
+                    if (finalResult.freeToPass)
+                        return null;
+                    
+                    
+                    // First line defense...
+                    for(CachedEntity defender:charactersInBlockade)
+                        if ("Defending1".equals(defender.getProperty("status")) && 
+                                (ODPDBAccess.CHARACTER_MODE_COMBAT.equals(defender.getProperty("mode"))==false) &&
+                                (Double)defender.getProperty("hitpoints")>0 &&
+                                defender.getKey().getId() != character.getKey().getId())
+                        {
+                            
+                            chosenOpponent=defender;
+                            break;
+                        }
+                    
+                    
+                    // Second line defense...
+                    if (chosenOpponent==null)
+                        for(CachedEntity defender:charactersInBlockade)
+                            if ("Defending2".equals(defender.getProperty("status")) && 
+                                    (ODPDBAccess.CHARACTER_MODE_COMBAT.equals(defender.getProperty("mode"))==false) &&
+                                    (Double)defender.getProperty("hitpoints")>0 &&
+                                    defender.getKey().getId() != character.getKey().getId())
+                            {
+                                
+                                chosenOpponent=defender;
+                                break;
+                            }
+                    
+                    
+                    // Third line defense...
+                    if (chosenOpponent==null)
+                        for(CachedEntity defender:charactersInBlockade)
+                            if ("Defending3".equals(defender.getProperty("status")) && 
+                                    (ODPDBAccess.CHARACTER_MODE_COMBAT.equals(defender.getProperty("mode"))==false) &&
+                                    (Double)defender.getProperty("hitpoints")>0 &&
+                                    defender.getKey().getId() != character.getKey().getId())
+                            {
+                                
+                                chosenOpponent=defender;
+                                break;
+                            }
+                    
+                    if (chosenOpponent!=null)
+                    {
+                        CachedEntity opponent = null;
+                        opponent = ds.refetch(chosenOpponent);
+                        
+                        // Compare the fetched opponent and the chosen opponent for property value equality. If anything changed, do it over
+                        if (opponent.getProperties().equals(chosenOpponent.getProperties())==false)
+                            throw new ConcurrentModificationException();
+                        
+                        character.setProperty("combatant", opponent.getKey());
+                        character.setProperty("mode", ODPDBAccess.CHARACTER_MODE_COMBAT);
+                        character.setProperty("combatType", "DefenceStructureAttack");
+                        db.flagCharacterCombatAction(ds, character);
+                        
+                        opponent.setProperty("combatant", character.getKey());
+                        opponent.setProperty("mode", ODPDBAccess.CHARACTER_MODE_COMBAT);
+                        
+                        ds.put(opponent);
+                        ds.put(character);
+                    }
+                    
+                    finalResult.defender = chosenOpponent;
+                    
+                    return chosenOpponent;
+                }
+            }.run();
+        } 
+        catch (AbortTransactionException e) 
+        {
+            throw new UserErrorMessage(e.getMessage());
+        }
+
+        if (finalResult.defender!=null)
+            db.sendNotification(ds, finalResult.defender.getKey(), NotificationType.fullpageRefresh);
+
+        return finalResult;
+    }
+
+    /**
+     * This simply determines if the character will be blocked by a blockade based on the blockade's rules.
+     * 
+     * @param character
+     * @param location
+     * @return
+     */
+    private boolean isBlockedByBlockadeRules(CachedEntity character, Key destinationLocationKey, CachedEntity blockadeStructure)
+    {
+        if (character==null)
+            throw new IllegalArgumentException("Character cannot be null.");
+        if (destinationLocationKey==null)
+            throw new IllegalArgumentException("Parent location cannot be null.");
+        if (blockadeStructure==null)
+            throw new IllegalArgumentException("Blockade structure cannot be null.");
+        
+        
+        if ("BlockAllParent".equals(blockadeStructure.getProperty("blockadeRule")))
+            return true;
+        else if ("BlockAllSelf".equals(blockadeStructure.getProperty("blockadeRule")) && 
+        		destinationLocationKey.getId() == ((Key)blockadeStructure.getProperty("locationKey")).getId())
+            return true;
+        else
+            return false;
+    }
+    
+	/**
+	* This will cause the defender's combatant to be allowed entry into the defensive structure location.
+	*
+	* @param ds
+	* @param defender
+	*/
+	public void doCharacterAllowEntryIntoDefenceStructure(CachedEntity defender)
+	{
+		CachedDatastoreService ds = db.getDB();
+		
+		if (defender==null)
+			throw new IllegalArgumentException("Defender cannot be null.");
+		
+		
+		Key defenderLocationKey = (Key)defender.getProperty("locationKey");
+		
+		CachedEntity characterToAllowIn = db.getEntity((Key)defender.getProperty("combatant"));
+		
+		defender.setProperty("mode", ODPDBAccess.CHARACTER_MODE_NORMAL);
+		defender.setProperty("combatant", null);
+		defender.setProperty("combatType", null);
+		
+		Double hitpoints = (Double)defender.getProperty("hitpoints");
+		Double maxHitpoints = (Double)defender.getProperty("maxHitpoints");
+		if (hitpoints<maxHitpoints)
+			defender.setProperty("hitpoints", maxHitpoints);
+	
+		characterToAllowIn.setProperty("mode", ODPDBAccess.CHARACTER_MODE_NORMAL);
+		characterToAllowIn.setProperty("combatant", null);
+		characterToAllowIn.setProperty("combatType", null);
+		characterToAllowIn.setProperty("locationKey", defenderLocationKey);
+	
+		ds.put(defender);
+		ds.put(characterToAllowIn);
+		db.sendNotification(ds, characterToAllowIn.getKey(), NotificationType.fullpageRefresh);
+		// TODO: Check to make sure the character is actually defending a structure so we don't just teleport random people.
+		// Right now it's not possible to enter combat with anyone who isn't dueling you or attacking your defending structure so it's ok, but eventually
+		// this might not be the only cases.
+	}
+	
+	public void setBlockadeRule(CachedEntity character, 
+			CachedEntity location, String newRule) throws UserErrorMessage 
+	{
+		ODPDBAccess.BlockadeRule.valueOf(newRule);	// Check if this is a valid value, it will throw an IllegalArgumentException if it's not
+	
+		CachedDatastoreService ds=db.getDB();
+		
+		CachedEntity defenceStructure = db.getEntity((Key)location.getProperty("defenceStructure"));
+		
+		if (defenceStructure==null)
+			throw new UserErrorMessage("You're not near a defence structure and so you cannot change the defence mode.");
+		if (defenceStructure.getProperty("leaderKey")==null || ((Key)defenceStructure.getProperty("leaderKey")).getId() != character.getKey().getId())
+			throw new UserErrorMessage("You are not the leader of this defence structure and so cannot change the defence mode.");
+
+		if ("FALSE".equals(defenceStructure.getProperty("blockadeRuleChangeable")))
+			throw new UserErrorMessage("You cannot change the blockade rule for this structure, it is not configurable.");
+		
+		if ((defenceStructure.getProperty("blockadeRule")==null && newRule!=null) || defenceStructure.getProperty("blockadeRule").equals(newRule)==false)
+		{
+			defenceStructure.setProperty("blockadeRule", newRule);
+			ds.put(defenceStructure);
+		}
+		
+	}
+	
+	public void doCharacterAttackStructure(CachedEntity character, CachedEntity location) throws UserErrorMessage
+	{
+		if (location.getProperty("defenceStructure")==null)
+			throw new UserErrorMessage("There is no defence structure here to attack.");
+		
+		EngageBlockadeOpponentResult result = engageBlockadeOpponent(
+			character.getKey(), null, null, location.getKey(), 
+			db.getEntity((Key)location.getProperty("defenceStructure")));
+			
+		if (result.charactersInBlockade!=null && result.charactersInBlockade.size()==1 && 
+				result.charactersInBlockade.get(0).getKey().getId() == character.getKey().getId())
+			throw new UserErrorMessage("Dude, relax. You can't attack yourself and you're the only one defending here.");
+		if (result.hasDefenders==true && result.defender==null && result.onlyNPCDefenders==false)
+			throw new UserErrorMessage("Unable to attack at the moment, all defenders are already in combat.");
+		if (result.hasDefenders==false)
+			throw new UserErrorMessage("You cannot attack because there is no one defending the tower!");
+		
+	}
+}

--- a/Initium-Odp/src/com/universeprojects/miniup/server/services/MainPageUpdateService.java
+++ b/Initium-Odp/src/com/universeprojects/miniup/server/services/MainPageUpdateService.java
@@ -414,9 +414,9 @@ public class MainPageUpdateService extends Service
 		return "TRUE".equals(character.getProperty("partyLeader"));
 	}
 	
-	
-	public void shortcut_fullPageUpdate(CombatService combatService)
+	public void shortcut_fullPageUpdate()
 	{
+		CombatService combatService = new CombatService(db);
 		updateMoney();
 		updateInBannerOverlayLinks();
 		updateButtonList(combatService);


### PR DESCRIPTION
Update party members after taking path (and possibly entering combat)
Taking path should no longer steal combatants
Explore should properly prevent certain combat situations now
Exploring into non-instance (non-combat site) locations will force all party members into combat with a different combatant