### PR TITLE
Fix HCM Leaderboard; characters with a score of 0 shouldn't appear.

### DIFF
--- a/Initium-Odp/src/com/universeprojects/miniup/server/controllers/HCMLeaderboardController.java
+++ b/Initium-Odp/src/com/universeprojects/miniup/server/controllers/HCMLeaderboardController.java
@@ -51,8 +51,8 @@ public class HCMLeaderboardController extends PageController
 		for(int i = 0; i<characters.size(); i++)
 		{
 			CachedEntity character = characters.get(i);
-						
-			if((int)character.getProperty("hardcoreRank")<=0||character.getProperty("hardcoreRank")==null) continue;
+			
+			if(character.getProperty("hardcoreRank")==null || (int)character.getProperty("hardcoreRank")<=0) continue;
 			
 			if (CommonChecks.checkCharacterIsIncapacitated(character) && GameUtils.getElapsedDays((Date)character.getProperty("locationEntryDatetime"))>1)
 				continue;

--- a/Initium-Odp/src/com/universeprojects/miniup/server/controllers/HCMLeaderboardController.java
+++ b/Initium-Odp/src/com/universeprojects/miniup/server/controllers/HCMLeaderboardController.java
@@ -51,8 +51,8 @@ public class HCMLeaderboardController extends PageController
 		for(int i = 0; i<characters.size(); i++)
 		{
 			CachedEntity character = characters.get(i);
-			
-			if((int)character.getProperty("hardcoreRank")<=0) continue;
+						
+			if((int)character.getProperty("hardcoreRank")<=0||character.getProperty("hardcoreRank")==null) continue;
 			
 			if (CommonChecks.checkCharacterIsIncapacitated(character) && GameUtils.getElapsedDays((Date)character.getProperty("locationEntryDatetime"))>1)
 				continue;

--- a/Initium-Odp/src/com/universeprojects/miniup/server/controllers/HCMLeaderboardController.java
+++ b/Initium-Odp/src/com/universeprojects/miniup/server/controllers/HCMLeaderboardController.java
@@ -52,7 +52,9 @@ public class HCMLeaderboardController extends PageController
 		{
 			CachedEntity character = characters.get(i);
 			
-			if (CommonChecks.checkIsHardcore(character)&&CommonChecks.checkCharacterIsIncapacitated(character) && GameUtils.getElapsedDays((Date)character.getProperty("locationEntryDatetime"))>1)
+			if((int)character.getProperty("hardcoreRank")<=0) continue;
+			
+			if (CommonChecks.checkCharacterIsIncapacitated(character) && GameUtils.getElapsedDays((Date)character.getProperty("locationEntryDatetime"))>1)
 				continue;
 			
 			Map<String,String> data = new HashMap<>();

--- a/Initium-Odp/src/com/universeprojects/miniup/server/controllers/HCMLeaderboardController.java
+++ b/Initium-Odp/src/com/universeprojects/miniup/server/controllers/HCMLeaderboardController.java
@@ -52,7 +52,7 @@ public class HCMLeaderboardController extends PageController
 		{
 			CachedEntity character = characters.get(i);
 			
-			if (CommonChecks.checkCharacterIsIncapacitated(character) && GameUtils.getElapsedDays((Date)character.getProperty("locationEntryDatetime"))>1)
+			if (CommonChecks.checkIsHardcore(character)&&CommonChecks.checkCharacterIsIncapacitated(character) && GameUtils.getElapsedDays((Date)character.getProperty("locationEntryDatetime"))>1)
 				continue;
 			
 			Map<String,String> data = new HashMap<>();


### PR DESCRIPTION
added a new check, if a character would be loaded onto the leaderboard but has an empty score, it gets cut. This should also keep non-HCM characters from appearing on the leaderboard.