### PR TITLE
Improve Item Splitting Logic

### DIFF
--- a/Initium-Odp/src/com/universeprojects/miniup/server/commands/CommandItemsStackSplit.java
+++ b/Initium-Odp/src/com/universeprojects/miniup/server/commands/CommandItemsStackSplit.java
@@ -28,8 +28,8 @@ public class CommandItemsStackSplit extends CommandItemsBase {
 	protected void processBatchItems(Map<String, String> parameters, ODPDBAccess db, CachedDatastoreService ds,
 			CachedEntity character, List<CachedEntity> batchItems) throws UserErrorMessage {
 		Long splitItemQuantity;
-		if (batchItems.size() > 10) {
-			throw new UserErrorMessage("You can only split 10 item at a time.");
+		if (batchItems.size() > 12) {
+			throw new UserErrorMessage("You can only split 12 items at a time.");
 		}
 		ds.beginTransaction();
 		try {
@@ -45,6 +45,14 @@ public class CommandItemsStackSplit extends CommandItemsBase {
 			}
 			if (stackSize <= 0 || stacks <= 0) {
 				throw new UserErrorMessage("Please input a positive integer value.");
+			}
+			
+			if(batchItems.size() > 1 && stacks > 1) {
+				throw new UserErrorMessage("You can't split multiple items into multiple stacks.");
+			}
+			
+			if(stacks > 24) {
+				throw new UserErrorMessage("Too many stacks. Max is 24.");
 			}
 			
 			//iterate through all of our items.

--- a/Initium-Odp/src/com/universeprojects/miniup/server/commands/CommandItemsStackSplit.java
+++ b/Initium-Odp/src/com/universeprojects/miniup/server/commands/CommandItemsStackSplit.java
@@ -28,9 +28,9 @@ public class CommandItemsStackSplit extends CommandItemsBase {
 	protected void processBatchItems(Map<String, String> parameters, ODPDBAccess db, CachedDatastoreService ds,
 			CachedEntity character, List<CachedEntity> batchItems) throws UserErrorMessage {
 		Long splitItemQuantity;
-		if (batchItems.size() > 12) {
+		if (batchItems.size() > 12) 
 			throw new UserErrorMessage("You can only split 12 items at a time.");
-		}
+		
 		ds.beginTransaction();
 		try {
 			
@@ -43,20 +43,18 @@ public class CommandItemsStackSplit extends CommandItemsBase {
 			catch (NumberFormatException e) {
 				throw new UserErrorMessage("Please input an integer value.");
 			}
-			if (stackSize <= 0 || stacks <= 0) {
+			
+			if (stackSize <= 0 || stacks <= 0) 
 				throw new UserErrorMessage("Please input a positive integer value.");
-			}
 			
-			if(batchItems.size() > 1 && stacks > 1) {
+			if(batchItems.size() > 1 && stacks > 1) 
 				throw new UserErrorMessage("You can't split multiple items into multiple stacks.");
-			}
 			
-			if(stacks > 24) {
+			if(stacks > 24) 
 				throw new UserErrorMessage("Too many stacks. Max is 24.");
-			}
 			
 			//iterate through all of our items.
-			for(CachedEntity splitItem:batchItems) {	
+			for(CachedEntity splitItem : batchItems) {	
 				if (CommonChecks.isItemCustom(splitItem)) {
 					sendError("You cannot split a custom item.", splitItem);
 					continue;
@@ -98,8 +96,9 @@ public class CommandItemsStackSplit extends CommandItemsBase {
 				splitItem.setProperty("quantity", newStackSize);
 				ds.put(splitItem);
 				
-				ds.commit();
 			}
+			
+			ds.commit();
 		} 
 		
 		finally {

--- a/Initium-Odp/war/odp/javascript/script.js
+++ b/Initium-Odp/war/odp/javascript/script.js
@@ -5523,12 +5523,18 @@ function mergeItemStacks(eventObject, selector)
 
 function splitItemStack(eventObject, selector)
 {
+
 	var batchItems = $(selector).has("input:checkbox:visible:checked");
 	if(batchItems.length == 0) return;
 	var itemIds = batchItems.map(function(i, selItem){ return $(selItem).attr("ref"); }).get().join(",");
+
 	promptPopup("Stack Split","Enter a stack size to create:","1",function(stackSize){
-		if (stackSize!=null&&stackSize!=""){
-			doCommand(eventObject, "ItemsStackSplit",{"itemIds":itemIds, "stackSize":stackSize});
+		if(stackSize != null && stackSize != ""){
+			promptPopup("Stack Split","Enter how many stacks you want:","1",function(stacks){
+				if(stacks != null && stacks != ""){
+					doCommand(eventObject, "ItemsStackSplit",{"itemIds":itemIds, "stackSize":stackSize, "stacks":stacks});
+				}
+			});
 		}
 	});
 }


### PR DESCRIPTION
-Allow for the user to specify both a stack size and a number of stacks.
-Allow for the user to select multiple stacks of items to split (up to 10, a number I arbitrarily decided)