### PR TITLE
Pinning quests

### DIFF
--- a/Initium-Odp/src/com/universeprojects/miniup/server/commands/CommandPinQuest.java
+++ b/Initium-Odp/src/com/universeprojects/miniup/server/commands/CommandPinQuest.java
@@ -1,0 +1,60 @@
+package com.universeprojects.miniup.server.commands;
+
+import java.util.Map;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import com.google.appengine.api.datastore.Key;
+import com.universeprojects.cacheddatastore.CachedEntity;
+import com.universeprojects.miniup.CommonChecks;
+import com.universeprojects.miniup.server.GameUtils;
+import com.universeprojects.miniup.server.ODPDBAccess;
+import com.universeprojects.miniup.server.UserRequestIncompleteException;
+import com.universeprojects.miniup.server.commands.framework.Command;
+import com.universeprojects.miniup.server.commands.framework.UserErrorMessage;
+import com.universeprojects.miniup.server.dbentities.QuestEntity;
+import com.universeprojects.miniup.server.services.QuestService;
+
+public class CommandPinQuest extends Command{
+
+	public CommandPinQuest(ODPDBAccess db, HttpServletRequest request, HttpServletResponse response) {
+		super(db, request, response);
+	}
+
+	@Override
+	public void run(Map<String, String> parameters) throws UserErrorMessage, UserRequestIncompleteException {		
+		QuestService qService = db.getQuestService(this);
+		CachedEntity character = db.getCurrentCharacter();
+		
+		if(CommonChecks.checkCharacterIsZombie(character))
+			throw new UserErrorMessage("You can't control yourself... Must... Eat... Brains...");
+		
+		Long questId = Long.parseLong(parameters.get("questId"));
+		CachedEntity rawQuest = db.getEntity("Quest", questId);
+		
+		if(rawQuest == null) 
+			throw new UserErrorMessage("This quest doesn't exist.");
+		
+		QuestEntity quest = new QuestEntity(db, rawQuest);
+		
+		if(GameUtils.equals(character.getKey(), quest.getKey()))
+			throw new UserErrorMessage("You don't own this quest.");
+		
+		if(quest.isComplete())
+			throw new UserErrorMessage("This quest is already complete.");
+		
+		if(GameUtils.equals(character.getProperty("pinnedQuest"), quest.getKey()))
+			character.setProperty("pinnedQuest", null);
+		
+		else character.setProperty("pinnedQuest", quest.getKey());
+		
+		CachedEntity questDef = db.getEntity(quest.getQuestDefKey());
+		db.sendGameMessage("You've pinned " + questDef.getProperty("name"));
+
+		ds.put(character);
+		
+		getMPUS().updateFullPage_shortcut();
+	}
+
+}

--- a/Initium-Odp/src/com/universeprojects/miniup/server/controllers/QuestController.java
+++ b/Initium-Odp/src/com/universeprojects/miniup/server/controllers/QuestController.java
@@ -76,9 +76,10 @@ public class QuestController extends PageController {
 		
 		description += "<div style ='text-align: center;color:#c7a46c;font-size:150%;'</div><a onclick='pinQuest(" + quest.getKey().getId();
 				
-		if(isPinned) description += ")'>Unpin this quest</a>";
-		
-		else description += ")'>Pin this quest</a>";
+		if(isPinned)
+			description += ")'>Unpin this quest</a>";
+		else
+			description += ")'>Pin this quest</a>";
 		
 //		// If the quest is now complete, lets save this new status
 //		boolean newQuestGiven = questService.updateQuest(quest, questDef, questComplete);

--- a/Initium-Odp/src/com/universeprojects/miniup/server/controllers/QuestController.java
+++ b/Initium-Odp/src/com/universeprojects/miniup/server/controllers/QuestController.java
@@ -9,6 +9,8 @@ import javax.servlet.http.HttpServletResponse;
 
 import com.google.appengine.api.datastore.Key;
 import com.google.appengine.api.datastore.KeyFactory;
+import com.universeprojects.cacheddatastore.CachedEntity;
+import com.universeprojects.miniup.server.GameUtils;
 import com.universeprojects.miniup.server.InitiumPageController;
 import com.universeprojects.miniup.server.NotLoggedInException;
 import com.universeprojects.miniup.server.ODPDBAccess;
@@ -38,7 +40,7 @@ public class QuestController extends PageController {
 		Key questDefKey = KeyFactory.stringToKey(questDefKeyString);
 		QuestDefEntity questDef = new QuestDefEntity(db, db.getDB().getIfExists(questDefKey));
 		QuestEntity quest = questDef.getQuestEntity(db.getCurrentCharacterKey());
-		
+				
 		if (quest==null)
 		{
 			return null;
@@ -47,6 +49,8 @@ public class QuestController extends PageController {
 		String description = questDef.getDescription();
 		
 		description+="<h2>Objectives</h2>";
+		
+		boolean isPinned = GameUtils.equals(db.getCurrentCharacter().getProperty("pinnedQuest"), quest.getKey());
 		
 		boolean questComplete = true;
 		List<QuestObjective> objectives = quest.getObjectiveData(questDef);
@@ -70,6 +74,11 @@ public class QuestController extends PageController {
 			description+="</ul>";
 		}
 		
+		description += "<div style ='text-align: center;color:#c7a46c;font-size:150%;'</div><a onclick='pinQuest(" + quest.getKey().getId();
+				
+		if(isPinned) description += ")'>Unpin this quest</a>";
+		
+		else description += ")'>Pin this quest</a>";
 		
 //		// If the quest is now complete, lets save this new status
 //		boolean newQuestGiven = questService.updateQuest(quest, questDef, questComplete);
@@ -83,8 +92,7 @@ public class QuestController extends PageController {
 		request.setAttribute("questComplete", questComplete);
 		request.setAttribute("name", questDef.getName());
 		request.setAttribute("description", description);
-		request.setAttribute("questDefKey", questDef.getUrlSafeKey());
-		
+		request.setAttribute("questDefKey", questDef.getUrlSafeKey());		
 		
 		
 		return "/WEB-INF/odppages/ajax_quest.jsp";

--- a/Initium-Odp/src/com/universeprojects/miniup/server/controllers/QuestListController.java
+++ b/Initium-Odp/src/com/universeprojects/miniup/server/controllers/QuestListController.java
@@ -41,11 +41,12 @@ public class QuestListController extends PageController {
 		List<QuestEntity> allQuests = questService.getAllQuests();
 		Map<Key, QuestDefEntity> allQuestDefs = questService.getMapOfAllQuestDefs();
 		
+		List<Map<String,Object>> activeQuests = new ArrayList<>();
+		List<Map<String,Object>> finishedQuests = new ArrayList<>();
+		
 		List<Map<String,Object>> data = new ArrayList<>();
-		boolean hasQuests = false;
 		if (allQuests!=null && allQuests.isEmpty()==false)
 		{
-			hasQuests = true;
 			
 			// Sort the active quests first
 			Collections.sort(allQuests, new Comparator<QuestEntity>()
@@ -58,28 +59,29 @@ public class QuestListController extends PageController {
 					return o1.getCreatedDate().compareTo(o2.getCreatedDate());
 				}
 			});
-		
 			
-			for(int i = 0; i<allQuests.size(); i++)
-			{
-				QuestEntity quest = allQuests.get(i);
+			for(QuestEntity quest : allQuests) {
 				QuestDefEntity questDef = allQuestDefs.get(quest.getQuestDefKey());
-				if (questDef==null) continue;
+				if(questDef == null) continue;
 				
 				Map<String, Object> questData = new HashMap<>();
 				
 				questData.put("name", questDef.getName());
 				questData.put("description", questDef.getDescription());
-				//TODO: THIS IS BAAAAAD, DO IT BETTER VERY SOON vvvvv
-				questData.put("complete", questDef.getQuestEntity(db.getCurrentCharacterKey()).getStatus()==QuestStatus.Complete);
+				
+				questData.put("complete", quest.isComplete());
 				questData.put("key", questDef.getUrlSafeKey());
 				
-				data.add(questData);
+				if(quest.isComplete()) finishedQuests.add(questData);
+				else activeQuests.add(questData);
+				
 			}
 		}
 		
-		request.setAttribute("data", data);
-		request.setAttribute("hasQuests", hasQuests);
+		request.setAttribute("activeQuests", activeQuests);
+		request.setAttribute("hasActiveQuests", activeQuests.size() > 0);
+		request.setAttribute("finishedQuests", finishedQuests);
+		request.setAttribute("hasFinishedQuests", finishedQuests.size() > 0);
 		
 		return "/WEB-INF/odppages/ajax_questlist.jsp";
 	}

--- a/Initium-Odp/src/com/universeprojects/miniup/server/controllers/ViewItemController.java
+++ b/Initium-Odp/src/com/universeprojects/miniup/server/controllers/ViewItemController.java
@@ -111,28 +111,28 @@ public class ViewItemController extends PageController {
 		
 		if (CommonChecks.checkItemIsChippedToken(item))
 			request.setAttribute("showChippedTokenUI", true);
-
-		if (item.getProperty("newQuest")!=null)
-		{
-			CachedEntity questDefEntity = db.getEntity((Key)item.getProperty("newQuest"));
-			if (questDefEntity!=null)
+		
+		if (CommonChecks.checkItemIsAccessible(item, character)) {
+			request.setAttribute("showRelatedSkills", true);
+			
+			if (item.getProperty("newQuest")!=null)
 			{
-//				QuestService questService = new QuestService(db, db.getCurrentCharacter());
-				QuestDefEntity questDef = new QuestDefEntity(db, questDefEntity);
-				QuestEntity quest = questDef.getQuestEntity(db.getCurrentCharacterKey());
-				
-				if (quest!=null && quest.isComplete())
-					request.setAttribute("questComplete", true);
-				
-				request.setAttribute("newQuest", true);
+				CachedEntity questDefEntity = db.getEntity((Key)item.getProperty("newQuest"));
+				if (questDefEntity!=null)
+				{
+//					QuestService questService = new QuestService(db, db.getCurrentCharacter());
+					QuestDefEntity questDef = new QuestDefEntity(db, questDefEntity);
+					QuestEntity quest = questDef.getQuestEntity(db.getCurrentCharacterKey());
+					
+					if (quest!=null && quest.isComplete())
+						request.setAttribute("questComplete", true);
+					
+					request.setAttribute("newQuest", true);
+					
+				}
 				
 			}
-			
 		}
-		
-		
-		if (CommonChecks.checkItemIsAccessible(item, character))
-			request.setAttribute("showRelatedSkills", true);
 
 		ds.beginBulkWriteMode();
 		

--- a/Initium-Odp/src/com/universeprojects/miniup/server/services/MainPageUpdateService.java
+++ b/Initium-Odp/src/com/universeprojects/miniup/server/services/MainPageUpdateService.java
@@ -13,6 +13,7 @@ import com.google.appengine.api.datastore.Key;
 import com.google.appengine.api.datastore.Query.FilterOperator;
 import com.universeprojects.cacheddatastore.CachedEntity;
 import com.universeprojects.cacheddatastore.EntityPool;
+import com.universeprojects.gefcommon.shared.elements.GameObject;
 import com.universeprojects.miniup.CommonChecks;
 import com.universeprojects.miniup.server.GameUtils;
 import com.universeprojects.miniup.server.HtmlComponents;
@@ -1886,12 +1887,29 @@ public class MainPageUpdateService extends Service
 		
 		QuestService qService = db.getQuestService(operation);
 		
-		List<QuestDefEntity> activeQuestDefs = qService.getActiveQuestDefs();
+		QuestEntity quest = null;
+		QuestDefEntity questDef = null;
 		
-		if (activeQuestDefs==null || activeQuestDefs.isEmpty()) return updateHtmlContents(".questPanel", html.toString());
+		QuestEntity pinnedQuest = qService.getPinnedQuest();
 		
-		QuestDefEntity questDef = activeQuestDefs.get(0);
-		QuestEntity quest = questDef.getQuestEntity(character.getKey());
+		//We have a pinned quest and its not complete
+		if(pinnedQuest != null && false == pinnedQuest.isComplete()) {
+			quest = pinnedQuest;
+			
+			CachedEntity rawQuestDef = db.getEntity((Key) quest.getRawEntity().getProperty("questDefKey"));
+			
+			questDef = new QuestDefEntity(db, rawQuestDef);
+		}
+		//otherwise, just grab the first active quest in the list.
+		else {
+			List<QuestDefEntity> activeQuestDefs = qService.getActiveQuestDefs();
+			
+			if (activeQuestDefs==null || activeQuestDefs.isEmpty()) return updateHtmlContents(".questPanel", html.toString());
+			
+			questDef = activeQuestDefs.get(0);
+			quest = questDef.getQuestEntity(character.getKey());
+		}
+		
 		QuestObjective currentObjective = quest.getCurrentObjective(questDef);
 
 		if (currentObjective==null) return updateHtmlContents(".questPanel", html.toString());

--- a/Initium-Odp/src/com/universeprojects/miniup/server/services/QuestService.java
+++ b/Initium-Odp/src/com/universeprojects/miniup/server/services/QuestService.java
@@ -132,6 +132,12 @@ public class QuestService extends Service
 		return activeQuests;
 	}
 	
+	public QuestEntity getPinnedQuest() {
+		CachedEntity rawQuest = db.getEntity((Key) character.getProperty("pinnedQuest"));
+		if(rawQuest == null) return null;
+		return new QuestEntity(db, rawQuest);
+	}
+	
 	public QuestEntity createQuestInstance(Key questDefKey)
 	{
 		QuestEntity quest = new QuestEntity(db, character.getKey(), questDefKey);

--- a/Initium-Odp/war/WEB-INF/odppages/ajax_questlist.jsp
+++ b/Initium-Odp/war/WEB-INF/odppages/ajax_questlist.jsp
@@ -6,19 +6,25 @@
 
 <center><a class='standard-button-highlight' onclick='viewTrainingQuestLines();'><img alt='Training quests' src='https://initium-resources.appspot.com/images/ui3/quest-banners/button-training-quests1.png'/></a></center>
 
-<h4>Quests</h4>
-<c:if test="${hasQuests!=true}">
+<h2>Quests</h2>
+<c:if test="${hasActiveQuests!=true && hasFinishedQuests!=true}">
 	You don't have any quests at the moment.
 </c:if>
-<c:if test="${hasQuests==true}">
-	<c:forEach var="quest" items="${data}">
-		<c:if test="${quest.complete==true}">
-		<div class='quest-container quest-complete' id='questlist-questkey-${quest.key}'>
-		</c:if>
-		<c:if test="${quest.complete==false}">
+<c:if test="${hasActiveQuests==true}">
+	<h4>Active Quests</h4>
+	<c:forEach var="quest" items="${activeQuests}">
 		<div class='quest-container' id='questlist-questkey-${quest.key}'>
-		</c:if>
 			<a onclick='viewQuest("${quest.key}")'>${quest.name}</a>
 		</div>
 	</c:forEach>
 </c:if>
+
+<c:if test="${hasFinishedQuests == true }">
+	<h4>Finished Quests</h4>
+	<c:forEach var="finishedQuest" items="${finishedQuests}">
+		<div class='quest-container quest-complete' id='questlist-questkey-${finishedQuest.key}'>
+			<a onclick='viewQuest("${finishedQuests.key}")'>${finishedQuests.name}</a>
+		</div>
+	</c:forEach>
+</c:if>
+

--- a/Initium-Odp/war/odp/javascript/script.js
+++ b/Initium-Odp/war/odp/javascript/script.js
@@ -2592,6 +2592,11 @@ function viewQuests()
 	pagePopup("/odp/questlist", null, "Available Quests");
 }
 
+function pinQuest(id)
+{
+	doCommand(event, "PinQuest", {questId:id})
+}
+
 function viewQuest(keyString)
 {
 	createQuestWindow("<div id='quest-id-"+keyString+"'><div style='text-align:center'><img src='/javascript/images/wait.gif' border=0/></div></div>");


### PR DESCRIPTION
- Add a new command for pinning quests. When pinned, a quest will be forced to appear on the main page.
- Seperate the quest list into active and finished quests
- Don't show begin quest dialog on an item if it's inaccessible