### PR TITLE
Deleting groups throws an error because character gets put twice

### DIFF
--- a/Initium-Odp/src/com/universeprojects/miniup/server/commands/CommandGroupDelete.java
+++ b/Initium-Odp/src/com/universeprojects/miniup/server/commands/CommandGroupDelete.java
@@ -79,9 +79,6 @@ public class CommandGroupDelete extends Command
 
 		db.doLeaveGroup(ds, character); // Sets group properties to null
 
-		ds.put(character); // This is a bit redundant since it happens in
-							// doLeaveGroup but I'll leave it anyways
-
 		setPopupMessage(groupName + " has been deleted.");
 	}
 }


### PR DESCRIPTION
This isn't just redundant, it throws an error.