### PR TITLE
Fix rubberbanding

### DIFF
--- a/Initium-Odp/src/com/universeprojects/miniup/server/longoperations/LongOperationTakePath.java
+++ b/Initium-Odp/src/com/universeprojects/miniup/server/longoperations/LongOperationTakePath.java
@@ -315,6 +315,9 @@ public class LongOperationTakePath extends LongOperation {
 			if ((path.getProperty("travelTime")!=null && ((Long)path.getProperty("travelTime"))>0) || longDistanceTravel)
 				buffedTravel = db.getPathTravelTime(path, character);
 			
+			if(buffedTravel == 0)
+				buffedTravel = 1L; //time of 0 sometimes rubberbands.
+			
 			setDataProperty("secondsToWait", buffedTravel);
 			
 			setLongOperationName("Walking to "+destination.getProperty("name"));


### PR DESCRIPTION
Paths with 0 travel time sometimes rubberband the user back down the path after completion. Having a time of 1 instead of 0 is unnoticeable by the player but should fix this issue.