### PR TITLE
Scripts in combat

### DIFF
--- a/Initium-Odp/src/com/universeprojects/miniup/server/commands/CommandScriptBase.java
+++ b/Initium-Odp/src/com/universeprojects/miniup/server/commands/CommandScriptBase.java
@@ -167,15 +167,8 @@ public abstract class CommandScriptBase extends Command {
 			{
 				if(!event.haltExecution)
 				{
-					for(CachedEntity saveEntity:event.getSaveEntities())
-						ds.put(saveEntity);
-					for(CachedEntity delEntity:event.getDeleteEntities())
-						ds.delete(delEntity);
-					
+					service.cleanupEvent(event);
 					ds.commitBulkWrite();
-					
-					for(Entry<Level, String> logs:event.logEntries.entrySet())
-						ScriptService.log.log(logs.getKey(), logs.getValue());
 					
 					this.mergeOperationUpdates(event);
 					
@@ -208,14 +201,6 @@ public abstract class CommandScriptBase extends Command {
 						{
 							for(String method:update.getValue())
 								db.sendMainPageUpdateForCharacter(ds, update.getKey(), method);
-						}
-					}
-					
-
-					//send all the specified game messages to the appropriate characters.
-					for(Entry<Key, List<String>> messagesToSend : event.getGameMessages().entrySet()) {
-						for(String message : messagesToSend.getValue()){
-							db.sendGameMessage(db.getDB(), messagesToSend.getKey(), message);
 						}
 					}
 				}

--- a/Initium-Odp/src/com/universeprojects/miniup/server/commands/CommandScriptCombat.java
+++ b/Initium-Odp/src/com/universeprojects/miniup/server/commands/CommandScriptCombat.java
@@ -13,6 +13,7 @@ import com.universeprojects.miniup.server.ODPDBAccess.ScriptType;
 import com.universeprojects.miniup.server.commands.framework.UserErrorMessage;
 import com.universeprojects.miniup.server.scripting.events.CombatEvent;
 import com.universeprojects.miniup.server.scripting.events.ScriptEvent;
+import com.universeprojects.miniup.server.services.ScriptService;
 
 /**
  * Makes it possible to execute script during combat.
@@ -60,7 +61,7 @@ public class CommandScriptCombat extends CommandScriptBase {
 		CachedEntity combatant = db.getCharacterCombatant(character);
 		
 		if(combatant == null) throw new RuntimeException("Character is in COMBAT mode, but combatant is null");
-		return new CombatEvent(db, character, trigger, combatant);
+		return ScriptService.getScriptService(db).generateCombatEvent(character, trigger, combatant, ScriptType.combatItem);
 	}
 
 	@Override

--- a/Initium-Odp/src/com/universeprojects/miniup/server/scripting/events/AttackEvent.java
+++ b/Initium-Odp/src/com/universeprojects/miniup/server/scripting/events/AttackEvent.java
@@ -1,0 +1,17 @@
+package com.universeprojects.miniup.server.scripting.events;
+
+import com.universeprojects.cacheddatastore.CachedEntity;
+import com.universeprojects.miniup.server.ODPDBAccess;
+
+/**
+ * unimplemented
+ * @author Evan
+ *
+ */
+public class AttackEvent extends CombatEvent{
+
+	public AttackEvent(ODPDBAccess db, CachedEntity character, CachedEntity weapon, CachedEntity defender) {
+		super(db, character, weapon, defender);
+		// TODO Auto-generated constructor stub
+	}
+}

--- a/Initium-Odp/src/com/universeprojects/miniup/server/scripting/events/AttackHitEvent.java
+++ b/Initium-Odp/src/com/universeprojects/miniup/server/scripting/events/AttackHitEvent.java
@@ -1,0 +1,15 @@
+package com.universeprojects.miniup.server.scripting.events;
+
+import com.universeprojects.cacheddatastore.CachedEntity;
+import com.universeprojects.miniup.server.ODPDBAccess;
+
+public class AttackHitEvent extends CombatEvent{
+	public String status; //this will get appended to the hidden text of an attack.
+	public Long damage; //this will get added to the damage calculation before damage is applied. Status should reflect this.
+
+	public AttackHitEvent(ODPDBAccess db, CachedEntity character, CachedEntity weapon, CachedEntity defender) {
+		super(db, character, weapon, defender);
+		// TODO Auto-generated constructor stub
+	}
+
+}

--- a/Initium-Odp/src/com/universeprojects/miniup/server/scripting/events/CombatEvent.java
+++ b/Initium-Odp/src/com/universeprojects/miniup/server/scripting/events/CombatEvent.java
@@ -24,11 +24,11 @@ import com.universeprojects.miniup.server.scripting.wrappers.Item;
  *   
  * @author spfiredrake
  */
-public class CombatEvent extends ScriptEvent {
+public abstract class CombatEvent extends ScriptEvent {
 	public Character attacker;
 	public Character defender;
 	public Item weapon;
-	public Map<String, Long> damage = new HashMap<String, Long>();
+	//public Map<String, Long> damage = new HashMap<String, Long>();
 	
 	/**
 	 * Initializes the combat event with the character as both the event source and attacking entity.
@@ -91,6 +91,13 @@ public class CombatEvent extends ScriptEvent {
 		super(character);
 	}
 	
+	@Override
+	public String eventKind() {
+		return "Combat";
+	}
+	
+	//We don't need these methods yet.
+	/*
 	public void setContext(ODPDBAccess db, CachedEntity attacker, CachedEntity weapon, CachedEntity defender)
 	{
 		this.attacker = new Character(attacker, db);
@@ -99,12 +106,7 @@ public class CombatEvent extends ScriptEvent {
 		this.damage.clear();
 		this.reset();
 	}
-	
-	@Override
-	public String eventKind() {
-		return "Combat";
-	}
-	
+
 	public Long addDamage(String damageType, Long damageDealt)
 	{
 		if(!damage.containsKey(damageType))
@@ -129,7 +131,7 @@ public class CombatEvent extends ScriptEvent {
 		for(Long dmg:damage.values())
 			totDamage += dmg;
 		return totDamage;
-	}
+	}*/
 	
 	@SuppressWarnings("unchecked")
 	public static Map<ScriptType, HashMap<CachedEntity, List<CachedEntity>>> 

--- a/Initium-Odp/src/com/universeprojects/miniup/server/scripting/events/DefendEvent.java
+++ b/Initium-Odp/src/com/universeprojects/miniup/server/scripting/events/DefendEvent.java
@@ -1,0 +1,18 @@
+package com.universeprojects.miniup.server.scripting.events;
+
+import com.universeprojects.cacheddatastore.CachedEntity;
+import com.universeprojects.miniup.server.ODPDBAccess;
+
+/**
+ * unimplemented
+ * @author Evan
+ *
+ */
+public class DefendEvent extends CombatEvent{
+
+	public DefendEvent(CachedEntity character, ODPDBAccess db) {
+		super(character, db);
+		// TODO Auto-generated constructor stub
+	}
+
+}

--- a/Initium-Odp/src/com/universeprojects/miniup/server/scripting/events/DefendHitEvent.java
+++ b/Initium-Odp/src/com/universeprojects/miniup/server/scripting/events/DefendHitEvent.java
@@ -1,0 +1,13 @@
+package com.universeprojects.miniup.server.scripting.events;
+
+import com.universeprojects.cacheddatastore.CachedEntity;
+import com.universeprojects.miniup.server.ODPDBAccess;
+
+public class DefendHitEvent extends CombatEvent{
+
+	public DefendHitEvent(ODPDBAccess db, CachedEntity character, CachedEntity weapon, CachedEntity defender) {
+		super(db, character, weapon, defender);
+		// TODO Auto-generated constructor stub
+	}
+
+}

--- a/Initium-Odp/src/com/universeprojects/miniup/server/services/ScriptService.java
+++ b/Initium-Odp/src/com/universeprojects/miniup/server/services/ScriptService.java
@@ -22,6 +22,11 @@ import com.universeprojects.cacheddatastore.CachedEntity;
 import com.universeprojects.miniup.server.GameUtils;
 import com.universeprojects.miniup.server.ODPDBAccess;
 import com.universeprojects.miniup.server.ODPDBAccess.ScriptType;
+import com.universeprojects.miniup.server.scripting.events.AttackEvent;
+import com.universeprojects.miniup.server.scripting.events.AttackHitEvent;
+import com.universeprojects.miniup.server.scripting.events.CombatEvent;
+import com.universeprojects.miniup.server.scripting.events.DefendEvent;
+import com.universeprojects.miniup.server.scripting.events.DefendHitEvent;
 import com.universeprojects.miniup.server.scripting.events.ScriptEvent;
 import com.universeprojects.miniup.server.scripting.jsaccessors.DBAccessor;
 import com.universeprojects.miniup.server.scripting.wrappers.Buff;
@@ -240,11 +245,53 @@ public class ScriptService extends Service
 		}
 	}
 	
+	public CombatEvent generateCombatEvent(CachedEntity attacker, CachedEntity item, CachedEntity defender, ScriptType type) {
+		switch(type) {
+			case onAttack:
+				return new AttackEvent(db, attacker, item, defender); //unimplemented, for now.
+			case onAttackHit:
+				return new AttackHitEvent(db, attacker, item, defender);
+			case onDefend:
+				return new DefendEvent(null, db); //unimplemented, for now.
+			case onDefendHit:
+				return new DefendHitEvent(db, attacker, item, defender);
+			case combatItem:
+				return null; //unimplemented, for now.
+		default:
+			throw new IllegalArgumentException("Illegal script type " + type + " passed into ScriptService.generateCombatEvent");
+			
+		}
+	}
+	
 	@SuppressWarnings("unchecked")
 	public List<CachedEntity> getScriptsOfType(CachedEntity entity, ScriptType type){
 		List<Key> scriptKeys = (List<Key>) entity.getProperty("scripts");
 		
 		return db.getScriptsOfType(scriptKeys, type);
+	}
+	
+	/**
+	 * Returns an <embeddedentity-list<cachedentity>> map of the user's buffs and all scripts associated of the type on those buffs.
+	 * @param character
+	 * @param type
+	 * @return
+	 */
+	@SuppressWarnings("unchecked")
+	public Map<EmbeddedEntity, List<CachedEntity>> getCharacterBuffScriptsOfType(CachedEntity character, ScriptType type){
+		List<EmbeddedEntity> buffs = db.getBuffsFor(character);
+		
+		Map<EmbeddedEntity, List<CachedEntity>> result = new HashMap<>();
+		
+		for(EmbeddedEntity buff : buffs) {
+			List<Key> scriptKeys = (List<Key>) buff.getProperty("scripts");
+			
+			List<CachedEntity> scripts = db.getEntities(scriptKeys);
+			scripts.removeIf(n -> n.getProperty("type") != type);
+			
+			result.put(buff, scripts);
+		}
+		
+		return result;
 	}
 	
 	/**


### PR DESCRIPTION
- CombatEvent is now abstract, and there are various methods/changes to support that. This will allow for us to have different event objects at different injection points. Currently, that does nothing, with one exception; onAttackHit can append damage and a status message to the in-progress attack.
- Whenever a weapon hits an opponent, it will run all onAttackHit scripts associated with that item.
- Whenever any item blocks, it will run all onDefendHit scripts associated with that item.
- Whenever a character attacks(player swing or counterattack; dual hits only count as one trigger. this also deprecates onDefend entirely), all onAttack scripts associated with that character's buffs will trigger.